### PR TITLE
Swap isomorphic-git for nodegit

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -16,33 +16,45 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
+
       - uses: actions/checkout@v1
         with:
           fetch-depth: 1
+
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
           node-version: 13.x
+
       - name: Install Build dependencies
         if: runner.os == 'Linux'
-        run: sudo apt install build-essential libssl-dev libkrb5-dev libc++-dev
+        run: sudo apt install libkrb5-dev
+
       - name: Install dependencies
+        env:
+          JOBS: 'max'
         run: |
           npm config set '@fortawesome:registry=https://npm.fontawesome.com/'
           npm config set '//npm.fontawesome.com/:_authToken' "${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}"
-          npm ci
+          npm ci --ignore-scripts
+          npm run rebuild
+          node scripts/prepareNodeGit.js
+
       - name: Compile
         run: |
           npm run make
+
       - name: Test
         if: runner.os == 'Windows' || runner.os == 'macOS'
         run: |
           npm test
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:
           name: ${{ matrix.os }}
           path: out/make
+
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -36,8 +36,7 @@ jobs:
         run: |
           npm config set '@fortawesome:registry=https://npm.fontawesome.com/'
           npm config set '//npm.fontawesome.com/:_authToken' "${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}"
-          npm ci --ignore-scripts
-          npm run rebuild
+          npm ci
           node scripts/prepareNodeGit.js
 
       - name: Compile

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -23,6 +23,9 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 13.x
+      - name: Install Build dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get install libkrb5 libpcre libpcreposic libk5crypto libcom_err pcre-config krb5-config
       - name: Install dependencies
         run: |
           npm config set '@fortawesome:registry=https://npm.fontawesome.com/'

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 13.x
       - name: Install Build dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get install libkrb5 libpcre libpcreposic libk5crypto libcom_err pcre-config krb5-config
+        run: sudo apt install build-essential libssl-dev libkrb5-dev libc++-dev
       - name: Install dependencies
         run: |
           npm config set '@fortawesome:registry=https://npm.fontawesome.com/'

--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,7 @@
 @fortawesome:registry=https://npm.fontawesome.com/
-target=8.3.0
+target=9.2.0
 arch=x64
 target_arch=x64
 disturl=https://electronjs.org/headers
 runtime=electron
-# build_from_source=true
+build_from_source=true

--- a/.npmrc
+++ b/.npmrc
@@ -4,4 +4,3 @@ arch=x64
 target_arch=x64
 disturl=https://electronjs.org/headers
 runtime=electron
-build_from_source=true

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm start
 ```
 
 ## The Technical Stuff
-Aeon is an [Electron](https://www.electronjs.org/)-based app, a mature platform for building JavaScript applications on the desktop. It is backed by a locally encrypted Git repository, made available through use of the excellent [isomorphic-git](https://isomorphic-git.org/) package.
+Aeon is an [Electron](https://www.electronjs.org/)-based app, a mature platform for building JavaScript applications on the desktop. It is backed by a locally encrypted Git repository, made available through use of the excellent [nodegit](https://www.nodegit.org/) package.
 
 A custom and modular back-end allows for tracking and retrieving data from multiple sources. This is done through retrieval from an API, asynchronous data requests or a combination of both. Parser logic then allows for extracting common data types from the resulting JSON. 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -733,15 +733,6 @@
         "cross-spawn": "^7.0.1"
       }
     },
-    "@marshallofsound/webpack-asset-relocator-loader": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@marshallofsound/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.5.0.tgz",
-      "integrity": "sha512-X50R97SiDNTpOckiplghBo63Vo8GxSsr98s3VTwEu3qyVr+TY4I91KRtKelEj2OAfgMnkTymw89+psFVq8aB1g==",
-      "dev": true,
-      "requires": {
-        "sourcemap-codec": "^1.4.4"
-      }
-    },
     "@openfonts/ibm-plex-mono_all": {
       "version": "1.44.1",
       "resolved": "https://registry.npmjs.org/@openfonts/ibm-plex-mono_all/-/ibm-plex-mono_all-1.44.1.tgz",
@@ -1499,11 +1490,6 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
-    },
-    "@zeit/webpack-asset-relocator-loader": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.7.2.tgz",
-      "integrity": "sha512-n1mBPtL08njjX3KXk7G1YI213SbhryNbOVW08mu+iMjbbQFk/p+i36e5mCb9kSBWUrlKE3PeH3Er0FgiSBt5ww=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -11563,12 +11549,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "dev": true
-    },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "spawn-rx": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -791,7 +791,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
       "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
-      "dev": true,
       "requires": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "*",
@@ -863,8 +862,7 @@
     "@types/http-cache-semantics": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
-      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
-      "dev": true
+      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A=="
     },
     "@types/json-schema": {
       "version": "7.0.4",
@@ -882,7 +880,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
       "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -903,8 +900,7 @@
     "@types/node": {
       "version": "12.12.54",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
-      "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w==",
-      "dev": true
+      "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w=="
     },
     "@types/node-fetch": {
       "version": "2.5.7",
@@ -927,6 +923,14 @@
             "mime-types": "^2.1.12"
           }
         }
+      }
+    },
+    "@types/nodegit": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/@types/nodegit/-/nodegit-0.26.7.tgz",
+      "integrity": "sha512-qVwQupq4To/wkRtUnaiwbNhuRiVJShOG9CYIWiGdKQRkvWijtHmEnrC1KJHOVrzK04sMdHRClyecrfmN17VMFQ==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/parse-json": {
@@ -1003,7 +1007,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
       "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -1497,11 +1500,15 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "@zeit/webpack-asset-relocator-loader": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@zeit/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-0.7.2.tgz",
+      "integrity": "sha512-n1mBPtL08njjX3KXk7G1YI213SbhryNbOVW08mu+iMjbbQFk/p+i36e5mCb9kSBWUrlKE3PeH3Er0FgiSBt5ww=="
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
       "version": "1.3.7",
@@ -1848,7 +1855,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -1902,8 +1908,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -1944,8 +1949,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -1981,14 +1985,12 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
-      "dev": true
+      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
     "babel-plugin-styled-components": {
       "version": "1.10.7",
@@ -2009,8 +2011,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -2076,7 +2077,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -2181,7 +2181,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2324,7 +2323,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "dev": true,
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -2333,8 +2331,7 @@
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "dev": true
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -2345,8 +2342,7 @@
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-      "dev": true
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -2498,8 +2494,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.4.2",
@@ -2773,7 +2768,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       },
@@ -2781,8 +2775,7 @@
         "mimic-response": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "dev": true
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
         }
       }
     },
@@ -2829,7 +2822,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2873,8 +2865,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -3447,7 +3438,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -3623,8 +3613,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -3849,8 +3838,7 @@
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "duplexify": {
       "version": "3.7.1",
@@ -3900,7 +3888,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -5433,8 +5420,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -5574,8 +5560,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "3.1.1",
@@ -5969,8 +5954,7 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "5.0.14",
@@ -6076,7 +6060,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -6167,7 +6150,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
       "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-      "dev": true,
       "requires": {
         "minipass": "^2.6.0"
       }
@@ -6225,8 +6207,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.1.3",
@@ -6406,7 +6387,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -6420,7 +6400,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6579,8 +6558,7 @@
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-      "dev": true
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -6597,14 +6575,12 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "dev": true,
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -6614,7 +6590,6 @@
           "version": "6.12.3",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
           "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
-          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -6821,8 +6796,7 @@
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-      "dev": true
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "http-errors": {
       "version": "1.7.2",
@@ -6849,7 +6823,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -6903,7 +6876,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -6932,6 +6904,14 @@
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+    },
+    "ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -6974,7 +6954,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -7351,8 +7330,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -7402,8 +7380,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -7432,8 +7409,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "iterate-iterator": {
       "version": "1.0.1",
@@ -7469,8 +7445,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsesc": {
       "version": "2.5.2",
@@ -7492,8 +7467,7 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -7514,8 +7488,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "1.0.1",
@@ -7540,7 +7513,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -8234,14 +8206,12 @@
     "mime-db": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
-      "dev": true
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
       "version": "2.1.26",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
       "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
-      "dev": true,
       "requires": {
         "mime-db": "1.43.0"
       }
@@ -8322,7 +8292,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -8351,7 +8320,6 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
       "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -8361,7 +8329,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
       "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-      "dev": true,
       "requires": {
         "minipass": "^2.9.0"
       }
@@ -8735,9 +8702,7 @@
     "nan": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -8768,6 +8733,31 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "needle": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
+      "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "negotiator": {
       "version": "0.6.2",
@@ -8990,6 +8980,329 @@
         }
       }
     },
+    "node-pre-gyp": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz",
+      "integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "needle": "^2.2.1",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "nodegit": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/nodegit/-/nodegit-0.27.0.tgz",
+      "integrity": "sha512-E9K4gPjWiA0b3Tx5lfWCzG7Cvodi2idl3V5UD2fZrOrHikIfrN7Fc2kWLtMUqqomyoToYJLeIC8IV7xb1CYRLA==",
+      "requires": {
+        "fs-extra": "^7.0.0",
+        "got": "^10.7.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.14",
+        "nan": "^2.14.0",
+        "node-gyp": "^4.0.0",
+        "node-pre-gyp": "^0.13.0",
+        "ramda": "^0.25.0",
+        "tar-fs": "^1.16.3"
+      },
+      "dependencies": {
+        "@sindresorhus/is": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
+          "integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg=="
+        },
+        "@szmarczak/http-timer": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+          "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+          "requires": {
+            "defer-to-connect": "^2.0.0"
+          }
+        },
+        "bl": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+          "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "cacheable-lookup": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
+          "integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
+          "requires": {
+            "@types/keyv": "^3.1.1",
+            "keyv": "^4.0.0"
+          }
+        },
+        "cacheable-request": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+          "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+          "requires": {
+            "clone-response": "^1.0.2",
+            "get-stream": "^5.1.0",
+            "http-cache-semantics": "^4.0.0",
+            "keyv": "^4.0.0",
+            "lowercase-keys": "^2.0.0",
+            "normalize-url": "^4.1.0",
+            "responselike": "^2.0.0"
+          }
+        },
+        "decompress-response": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
+          "integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
+        },
+        "defer-to-connect": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
+          "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg=="
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "got": {
+          "version": "10.7.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
+          "integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
+          "requires": {
+            "@sindresorhus/is": "^2.0.0",
+            "@szmarczak/http-timer": "^4.0.0",
+            "@types/cacheable-request": "^6.0.1",
+            "cacheable-lookup": "^2.0.0",
+            "cacheable-request": "^7.0.1",
+            "decompress-response": "^5.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^5.0.0",
+            "lowercase-keys": "^2.0.0",
+            "mimic-response": "^2.1.0",
+            "p-cancelable": "^2.0.0",
+            "p-event": "^4.0.0",
+            "responselike": "^2.0.0",
+            "to-readable-stream": "^2.0.0",
+            "type-fest": "^0.10.0"
+          }
+        },
+        "json-buffer": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+          "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "keyv": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.1.tgz",
+          "integrity": "sha512-xz6Jv6oNkbhrFCvCP7HQa8AaII8y8LRpoSm661NOKLr4uHuBwhX4epXrPQgF3+xdJnN4Esm5X0xwY4bOlALOtw==",
+          "requires": {
+            "json-buffer": "3.0.1"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "node-gyp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-4.0.0.tgz",
+          "integrity": "sha512-2XiryJ8sICNo6ej8d0idXDEMKfVfFK7kekGCtJAuelGsYHQxhj13KTf95swTCN2dZ/4lTfZ84Fu31jqJEEgjWA==",
+          "requires": {
+            "glob": "^7.0.3",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2 || 3 || 4",
+            "osenv": "0",
+            "request": "^2.87.0",
+            "rimraf": "2",
+            "semver": "~5.3.0",
+            "tar": "^4.4.8",
+            "which": "1"
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "p-cancelable": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+          "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg=="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        },
+        "responselike": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+          "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+          "requires": {
+            "lowercase-keys": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
+          }
+        },
+        "tar-fs": {
+          "version": "1.16.3",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+          "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+          "requires": {
+            "chownr": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pump": "^1.0.0",
+            "tar-stream": "^1.1.2"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+              "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+              "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+              }
+            }
+          }
+        },
+        "tar-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+          "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+          "requires": {
+            "bl": "^1.0.0",
+            "buffer-alloc": "^1.2.0",
+            "end-of-stream": "^1.0.0",
+            "fs-constants": "^1.0.0",
+            "readable-stream": "^2.3.0",
+            "to-buffer": "^1.1.1",
+            "xtend": "^4.0.0"
+          }
+        },
+        "to-readable-stream": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
+          "integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w=="
+        },
+        "type-fest": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
+          "integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw=="
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "xtend": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+          "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        }
+      }
+    },
     "noop-logger": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
@@ -8999,7 +9312,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
       "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
-      "dev": true,
       "requires": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -9034,8 +9346,15 @@
     "normalize-url": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
-      "dev": true
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+    },
+    "npm-bundled": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
     },
     "npm-conf": {
       "version": "1.1.3",
@@ -9055,6 +9374,21 @@
           "dev": true,
           "optional": true
         }
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+    },
+    "npm-packlist": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "npm-run-path": {
@@ -9117,8 +9451,7 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -9499,20 +9832,17 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -9530,11 +9860,18 @@
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "dev": true
     },
+    "p-event": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+      "requires": {
+        "p-timeout": "^3.1.0"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
       "version": "2.1.0",
@@ -9556,6 +9893,14 @@
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
         "p-limit": "^2.0.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -9726,8 +10071,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -9786,8 +10130,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.2.2",
@@ -10094,8 +10437,7 @@
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -10217,8 +10559,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
       "version": "4.3.4",
@@ -10247,6 +10588,11 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
+    },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -10678,7 +11024,6 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -10817,7 +11162,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -10893,8 +11237,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sanitize-filename": {
       "version": "1.6.3",
@@ -10904,6 +11247,11 @@
       "requires": {
         "truncate-utf8-bytes": "^1.0.0"
       }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scheduler": {
       "version": "0.19.1",
@@ -11383,7 +11731,6 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -11910,7 +12257,6 @@
       "version": "4.4.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
       "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-      "dev": true,
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -12171,6 +12517,11 @@
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -12234,7 +12585,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dev": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -12390,8 +12740,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.4.0",
@@ -12671,8 +13020,7 @@
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",
@@ -12704,7 +13052,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -13397,8 +13744,7 @@
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yaml": {
       "version": "1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1941,11 +1941,6 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
-    "async-lock": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.2.4.tgz",
-      "integrity": "sha512-UBQJC2pbeyGutIfYmErGc9RaJYnpZ1FHaxuKwb0ahvGiiCkPUf3p67Io+YLPmmv3RHY+mF6JEtNW8FlHsraAaA=="
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2687,11 +2682,6 @@
         "source-map": "~0.6.0"
       }
     },
-    "clean-git-ref": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
-      "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw=="
-    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -3114,15 +3104,6 @@
             "ieee754": "^1.1.4"
           }
         }
-      }
-    },
-    "crc-32": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
-      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
-      "requires": {
-        "exit-on-epipe": "~1.0.1",
-        "printj": "~1.1.0"
       }
     },
     "crc32-stream": {
@@ -3695,11 +3676,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
-    },
-    "diff3": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-      "integrity": "sha1-1OXDpM305f4SEatC5pP8tDIVgPw="
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -5302,11 +5278,6 @@
         }
       }
     },
-    "exit-on-epipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
-      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
-    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -6900,11 +6871,6 @@
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
-    "ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
-    },
     "ignore-walk": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
@@ -7387,24 +7353,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isomorphic-git": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.7.4.tgz",
-      "integrity": "sha512-gzVg61bZLmfojR287p+nT9bbuFhSH0Us9f6pRVp4J9CA/1A/mghBEvcsCgRxalv+XKJ1sQMxWTc90tzn8WnYVA==",
-      "requires": {
-        "async-lock": "^1.1.0",
-        "clean-git-ref": "^2.0.1",
-        "crc-32": "^1.2.0",
-        "diff3": "0.0.3",
-        "ignore": "^5.1.4",
-        "minimisted": "^2.0.0",
-        "pako": "^1.0.10",
-        "pify": "^4.0.1",
-        "readable-stream": "^3.4.0",
-        "sha.js": "^2.4.9",
-        "simple-get": "^3.0.2"
-      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -8300,21 +8248,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
       "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
-    },
-    "minimisted": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
-      "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
-      "requires": {
-        "minimist": "^1.2.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        }
-      }
     },
     "minipass": {
       "version": "2.9.0",
@@ -9911,7 +9844,8 @@
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
     },
     "parallel-transform": {
       "version": "1.2.0",
@@ -10141,7 +10075,8 @@
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
@@ -10343,11 +10278,6 @@
       "requires": {
         "parse-ms": "^2.1.0"
       }
-    },
-    "printj": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
-      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
     },
     "process": {
       "version": "0.11.10",
@@ -11389,6 +11319,7 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "package": "electron-forge package",
         "make": "electron-forge make",
         "publish": "electron-forge publish",
-        "lint": "eslint --ext .ts .",
+        "lint": "eslint --ext .ts,.tsx .",
         "test": "mocha --exit --bail",
         "rebuild": "electron-rebuild && node scripts/prepareNodeGit.js"
     },

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
         "electron-squirrel-startup": "^1.0.0",
         "electron-store": "^6.0.0",
         "hex-to-rgba": "^2.0.1",
-        "isomorphic-git": "^1.7.4",
         "keytar": "^6.0.1",
         "lodash": "^4.17.19",
         "node-fetch": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "publish": "electron-forge publish",
         "lint": "eslint --ext .ts,.tsx .",
         "test": "mocha --exit --bail",
-        "rebuild": "electron-rebuild && node scripts/prepareNodeGit.js"
+        "postinstall": "node scripts/prepareNodeGit.js"
     },
     "keywords": [],
     "author": {
@@ -80,7 +80,6 @@
         "@electron-forge/maker-squirrel": "^6.0.0-beta.52",
         "@electron-forge/maker-zip": "^6.0.0-beta.52",
         "@electron-forge/plugin-webpack": "^6.0.0-beta.52",
-        "@marshallofsound/webpack-asset-relocator-loader": "0.5.0",
         "@types/adm-zip": "^0.4.33",
         "@types/deep-equal": "^1.0.1",
         "@types/lodash": "^4.14.159",
@@ -126,7 +125,6 @@
         "@openfonts/ibm-plex-sans_all": "^1.44.1",
         "@popperjs/core": "^2.4.4",
         "@types/nodegit": "^0.26.7",
-        "@zeit/webpack-asset-relocator-loader": "^0.7.2",
         "adm-zip": "^0.4.16",
         "cogo-toast": "^4.2.3",
         "date-fns": "^2.15.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "make": "electron-forge make",
         "publish": "electron-forge publish",
         "lint": "eslint --ext .ts .",
-        "test": "mocha --exit --bail"
+        "test": "mocha --exit --bail",
+        "rebuild": "electron-rebuild && node scripts/prepareNodeGit.js"
     },
     "keywords": [],
     "author": {
@@ -124,6 +125,8 @@
         "@openfonts/ibm-plex-mono_all": "^1.44.1",
         "@openfonts/ibm-plex-sans_all": "^1.44.1",
         "@popperjs/core": "^2.4.4",
+        "@types/nodegit": "^0.26.7",
+        "@zeit/webpack-asset-relocator-loader": "^0.7.2",
         "adm-zip": "^0.4.16",
         "cogo-toast": "^4.2.3",
         "date-fns": "^2.15.0",
@@ -135,6 +138,7 @@
         "keytar": "^6.0.1",
         "lodash": "^4.17.19",
         "node-fetch": "^2.6.0",
+        "nodegit": "^0.27.0",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
         "react-popper": "^2.2.3",

--- a/scripts/prepareNodeGit.js
+++ b/scripts/prepareNodeGit.js
@@ -1,0 +1,9 @@
+const path = require('path');
+const fs = require('fs');
+
+const debugPath = path.join(__dirname, '..', 'node_modules', 'nodegit', 'build', 'Debug');
+
+fs.promises.mkdir(debugPath, { recursive: true })
+    .then(() => {
+        return fs.promises.writeFile(path.join(debugPath, 'nodegit.node'), '');
+    });

--- a/src/app/pages/Log/components/Commit.tsx
+++ b/src/app/pages/Log/components/Commit.tsx
@@ -2,13 +2,13 @@
 import styled, { css } from 'styled-components'
 import React, { Component } from 'react';
 import theme from 'app/styles/theme';
-import { ReadCommitResult } from 'isomorphic-git';
 import { Badge } from 'app/components/Typography';
 import { PullRight } from 'app/components/Utility';
+import { Commit as CommitType } from 'main/lib/repository/types';
 
 interface Props extends Omit<React.HTMLAttributes<HTMLButtonElement>, 'onClick'> {
     onClick: (hash: string) => void;
-    entry: ReadCommitResult;
+    entry: CommitType;
     active?: boolean;
     latestCommit?: boolean;
 }
@@ -70,13 +70,13 @@ class Commit extends Component<Props> {
     }
 
     render(): JSX.Element {
-        const { entry: { commit }, active, latestCommit } = this.props;
+        const { entry, active, latestCommit } = this.props;
 
         return (
             <StyledCommit active={active} onClick={this.handleClick}>
                 <Timeline />
                 <Dot />
-                {commit.message}
+                {entry.message}
                 {latestCommit && <PullRight><Badge>Current Identity</Badge></PullRight>}
             </StyledCommit>
         )

--- a/src/app/pages/Log/components/Diff.tsx
+++ b/src/app/pages/Log/components/Diff.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from 'react';
-import { DiffResult, DiffType, ExtractedDataDiff, ObjectChange } from 'main/lib/repository/types';
+import { DiffResult, DiffType, ExtractedDataDiff, ObjectChange, Commit } from 'main/lib/repository/types';
 import Repository from 'app/utilities/Repository';
 import styled from 'styled-components';
 import DataType from 'app/utilities/DataType';
@@ -8,12 +8,11 @@ import { ProviderDatum } from 'main/providers/types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { H3, H5 } from 'app/components/Typography';
 import { Margin } from 'app/components/Utility';
-import { ReadCommitResult } from 'isomorphic-git';
 import { formatDistanceToNow } from 'date-fns';
 import Code from 'app/components/Code';
 
 interface Props {
-    commit: ReadCommitResult;
+    commit: Commit;
     diff?: ExtractedDataDiff;
 }
 
@@ -93,8 +92,8 @@ class Diff extends PureComponent<Props, State> {
         return (
             <Container>
                 <Margin>
-                    <H3>{commit.commit.message}</H3>
-                    Committed {formatDistanceToNow(new Date(commit.commit.author.timestamp * 1000))} ago
+                    <H3>{commit.message}</H3>
+                    Committed {formatDistanceToNow(new Date(commit.author.when))} ago
                 </Margin>
                 {diff.added.length ? (
                     <Code added>

--- a/src/app/pages/Log/index.tsx
+++ b/src/app/pages/Log/index.tsx
@@ -117,6 +117,8 @@ class Log extends Component<StoreProps, State> {
             return <Loading />;
         }
 
+        console.log(log);
+
         return (
             <Container>
                 <MenuBar>

--- a/src/app/pages/Log/index.tsx
+++ b/src/app/pages/Log/index.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import Repository from 'app/utilities/Repository';
-import { ReadCommitResult } from 'isomorphic-git';
 import styled from 'styled-components';
 import Commit, { StyledCommit } from './components/Commit';
 import Diff from './components/Diff';
@@ -10,7 +9,7 @@ import Providers from 'app/utilities/Providers';
 import Requests from './components/Requests';
 import { Link } from 'react-router-dom';
 import { TransitionDirection } from 'app/utilities/AnimatedSwitch';
-import { RepositoryEvents } from 'main/lib/repository/types';
+import { RepositoryEvents, Commit as CommitType } from 'main/lib/repository/types';
 import { IpcRendererEvent } from 'electron';
 import MenuBar from 'app/components/MenuBar';
 import { H2, H3 } from 'app/components/Typography';
@@ -22,7 +21,7 @@ import TutorialOverlay from './components/TutorialOverlay';
 import Store, { StoreProps } from 'app/store';
 
 interface State {
-    log: ReadCommitResult[];
+    log: CommitType[];
     selectedCommit?: string;
     updating: boolean;
 }
@@ -146,7 +145,7 @@ class Log extends Component<StoreProps, State> {
                             onClick={this.handleClick}
                         />
                     : null}
-                    {log.map((entry: ReadCommitResult, i) => (
+                    {log.map((entry, i) => (
                         <Commit
                             key={entry.oid}
                             entry={entry}

--- a/src/app/pages/Log/index.tsx
+++ b/src/app/pages/Log/index.tsx
@@ -117,8 +117,6 @@ class Log extends Component<StoreProps, State> {
             return <Loading />;
         }
 
-        console.log(log);
-
         return (
             <Container>
                 <MenuBar>

--- a/src/app/pages/NewCommit/index.tsx
+++ b/src/app/pages/NewCommit/index.tsx
@@ -26,9 +26,8 @@ import DataType from 'app/utilities/DataType';
 import Code from 'app/components/Code';
 import TutorialOverlay from './components/TutorialOverlay';
 import { TextInput, Label } from 'app/components/Input';
-import { CommitObject, ReadCommitResult } from 'isomorphic-git';
 import Store, { StoreProps } from 'app/store';
-import { ExtractedDataDiff } from 'main/lib/repository/types';
+import { ExtractedDataDiff, Commit } from 'main/lib/repository/types';
 
 type GroupedData =  { [key: string]: ProviderDatum<string, ProvidedDataTypes>[] };
 type DeletedData = { [key: string]: number[] };
@@ -125,21 +124,15 @@ class NewCommit extends Component<RouteComponentProps & StoreProps, State> {
         );
 
         // Then we'll construct a commit object that can be easily displayed in the log screen
-        const commit: ReadCommitResult & { diff: ExtractedDataDiff } = { 
+        const commit: Commit & { diff: ExtractedDataDiff } = { 
             oid: 'new-commit',
-            commit: {
-                message: newCommitMessage,
-                author: {
-                    timestamp: Math.floor(new Date().getTime() / 1000),
-                    name: undefined,
-                    email: undefined,
-                    timezoneOffset: undefined,
-                },
-                tree: null,
-                committer: null,
-                parent: null,
+            parents: [],
+            message: newCommitMessage,
+            author: {
+                when: Math.floor(new Date().getTime() / 1000),
+                name: undefined,
+                email: undefined,
             },
-            payload: null,
             diff: { 
                 deleted,
                 updated: [],

--- a/src/app/preload.ts
+++ b/src/app/preload.ts
@@ -3,7 +3,6 @@ import {
     ipcRenderer
 } from 'electron';
 import sourceMapSupport from 'source-map-support';
-import { WORKDIR, STAGE, TREE } from 'isomorphic-git';
 import store from 'main/store';
 
 declare global {
@@ -70,10 +69,5 @@ contextBridge.exposeInMainWorld(
             }
         },
         sourceMapSupport: sourceMapSupport,
-        git: {
-            TREE: TREE,
-            WORKDIR: WORKDIR,
-            STAGE: STAGE,
-        },
     },
-    );
+);

--- a/src/app/store/index.ts
+++ b/src/app/store/index.ts
@@ -1,7 +1,6 @@
-import { ReadCommitResult } from 'isomorphic-git';
 import { createConnectedStore, Store, Effects } from 'undux'
 import persistStore, { retrievePersistedStore } from './persist';
-import { ExtractedDataDiff } from 'main/lib/repository/types';
+import { ExtractedDataDiff, Commit } from 'main/lib/repository/types';
 
 type State = {
     // Whether onboarding has been completed
@@ -13,7 +12,7 @@ type State = {
     // A collection of events used for gauging usage of the application
     telemetry: any[];
     //
-    newCommit?: ReadCommitResult & {
+    newCommit?: Commit & {
         diff: ExtractedDataDiff
     };
     // The revision number for the data structure of the store. This helps track

--- a/src/app/utilities/Repository.ts
+++ b/src/app/utilities/Repository.ts
@@ -1,6 +1,6 @@
-import { DiffResult, RepositoryCommands, RepositoryArguments, RepositoryEvents } from 'main/lib/repository/types';
+import { DiffResult, RepositoryCommands, RepositoryArguments, RepositoryEvents, Commit } from 'main/lib/repository/types';
 import { ProviderDatum } from 'main/providers/types';
-import { ReadCommitResult, StatusRow } from 'isomorphic-git';
+import { StatusRow } from 'isomorphic-git';
 import { faInstagram, IconDefinition } from '@fortawesome/free-brands-svg-icons';
 import { faSquare } from '@fortawesome/pro-light-svg-icons';
 import { IpcRendererEvent } from 'electron';
@@ -26,7 +26,7 @@ class Repository {
         return window.api.invoke(channel, RepositoryCommands.PARSED_COMMIT, tree);
     }
 
-    static log(): Promise<ReadCommitResult[]> {
+    static log(): Promise<Commit[]> {
         return window.api.invoke(channel, RepositoryCommands.LOG);
     }
 

--- a/src/app/utilities/Repository.ts
+++ b/src/app/utilities/Repository.ts
@@ -1,6 +1,6 @@
 import { DiffResult, RepositoryCommands, RepositoryArguments, RepositoryEvents, Commit } from 'main/lib/repository/types';
 import { ProviderDatum } from 'main/providers/types';
-import { StatusRow } from 'isomorphic-git';
+import type { StatusFile } from 'nodegit';
 import { faInstagram, IconDefinition } from '@fortawesome/free-brands-svg-icons';
 import { faSquare } from '@fortawesome/pro-light-svg-icons';
 import { IpcRendererEvent } from 'electron';
@@ -30,7 +30,7 @@ class Repository {
         return window.api.invoke(channel, RepositoryCommands.LOG);
     }
 
-    static status(): Promise<StatusRow[]> {
+    static status(): Promise<StatusFile[]> {
         return window.api.invoke(channel, RepositoryCommands.STATUS);
     }
 

--- a/src/main/initialise.ts
+++ b/src/main/initialise.ts
@@ -11,10 +11,14 @@ function initialise(): void {
     // Inject the repository handler into the bridge for communication with the rendered
     new RepositoryBridge(repository);
 
-    // Also initialise the Provider Manager
-    const providerManager = new ProviderManager(repository);
-    // And also inject this into its respective bridge
-    new ProviderBridge(providerManager);
+    // Add an event listener for the repository being ready, so that we don't
+    // start any Git action before it is ready.
+    repository.addListener('ready', () => {
+        // Also initialise the Provider Manager
+        const providerManager = new ProviderManager(repository);
+        // And also inject this into its respective bridge
+        new ProviderBridge(providerManager);
+    });
 }
 
 export default initialise;

--- a/src/main/lib/repository/bridge.ts
+++ b/src/main/lib/repository/bridge.ts
@@ -47,7 +47,7 @@ class RepositoryBridge {
         
         switch(command) {
             case RepositoryCommands.LOG:
-                return this.repository.log(...args);
+                return this.repository.log();
             case RepositoryCommands.DIFF:
                 return this.repository.diff(...replaceArgs(args));
             case RepositoryCommands.STATUS:

--- a/src/main/lib/repository/bridge.ts
+++ b/src/main/lib/repository/bridge.ts
@@ -1,29 +1,9 @@
 import Repository from '.';
 import { RepositoryCommands, RepositoryArguments, RepositoryEvents } from './types';
 import { ipcMain, IpcMainInvokeEvent } from 'electron';
-import { TREE, WORKDIR, STAGE } from 'isomorphic-git';
 import WindowStore from '../window-store';
 
 const channelName = 'repository';
-
-/**
- * Replace instances of calls to TREE and STAGE with the appropriate objects, as
- * we can only call those functions in NodeJS.
- */
-function replaceArgs(args: any[]) {
-    return args.map(arg => {
-        switch(arg) {
-            case RepositoryArguments.HEAD:
-                return TREE({});
-            case RepositoryArguments.STAGE:
-                return STAGE();
-            case RepositoryArguments.WORKDIR:
-                return WORKDIR();
-            default:
-                return arg;
-            }
-    });
-}
 
 class RepositoryBridge {
     repository: Repository = null;
@@ -49,11 +29,11 @@ class RepositoryBridge {
             case RepositoryCommands.LOG:
                 return this.repository.log();
             case RepositoryCommands.DIFF:
-                return this.repository.diff(...replaceArgs(args));
+                return this.repository.diff(...args);
             case RepositoryCommands.STATUS:
                 return this.repository.status(...args);
             case RepositoryCommands.PARSED_COMMIT: {
-                return this.repository.getParsedCommit(...replaceArgs(args));
+                return this.repository.getParsedCommit(...args);
             }
         }
     }

--- a/src/main/lib/repository/index.ts
+++ b/src/main/lib/repository/index.ts
@@ -21,12 +21,9 @@ const fs = ENABLE_ENCRYPTION ? new CryptoFs('password').init() : nonCryptoFs;
 
 class Repository extends EventEmitter {
     /**
-     * The default config arguments for isomorphic-git
+     * The repository path for nodegit
      */
-    config = {
-        fs: fs,
-        dir: path.join(REPOSITORY_PATH, '.git'),
-    }
+    dir = path.join(REPOSITORY_PATH, '.git');
 
     /**
      * Whether the git repository is ready for querying
@@ -50,7 +47,7 @@ class Repository extends EventEmitter {
     constructor() {
         super();
 
-        NodeGit.Repository.open(this.config.dir)
+        NodeGit.Repository.open(this.dir)
             .catch(e => {
                 return this.initialiseRepository();
             })
@@ -73,7 +70,7 @@ class Repository extends EventEmitter {
 
         // First we'll initiate the repository
         // await git.init(this.config)
-        const repository = await NodeGit.Repository.init(this.config.dir, 0);
+        const repository = await NodeGit.Repository.init(this.dir, 0);
 
         // Then we'll write a file to disk so that the repository is populated
         const readmePath = 'README.md';

--- a/src/main/lib/repository/types.ts
+++ b/src/main/lib/repository/types.ts
@@ -1,4 +1,5 @@
 import { ProviderDatum } from 'main/providers/types';
+import type NodeGit from 'nodegit';
 
 export enum DiffType {
     // An object DiffType is the diff of an regular object
@@ -60,4 +61,15 @@ export enum RepositoryArguments {
 
 export enum RepositoryEvents {
     NEW_COMMIT,
+}
+
+export interface Commit {
+    oid: string;
+    parents: NodeGit.Oid[];
+    message: string;
+    author: {
+        email: string;
+        name: string;
+        when: number;
+    };
 }

--- a/src/main/lib/repository/types.ts
+++ b/src/main/lib/repository/types.ts
@@ -65,7 +65,7 @@ export enum RepositoryEvents {
 
 export interface Commit {
     oid: string;
-    parents: NodeGit.Oid[];
+    parents: string[];
     message: string;
     author: {
         email: string;

--- a/src/main/lib/repository/utilities/diff-map.ts
+++ b/src/main/lib/repository/utilities/diff-map.ts
@@ -1,6 +1,6 @@
 import generateDiff from './generate-diff';
-import { WalkerEntry } from 'isomorphic-git';
 import { DiffResult } from '../types';
+import { TreeEntry } from 'nodegit';
 
 
 /**
@@ -8,7 +8,7 @@ import { DiffResult } from '../types';
  * @param filepath The filepath for the currently handled file
  * @param entries The references to the walker functions for the individual trees
  */
-const diffMapFunction = async function(filepath: string, entries: Array<WalkerEntry>): Promise<DiffResult<unknown>> {
+const diffMapFunction = async function(filepath: string, entries: Array<TreeEntry>): Promise<DiffResult<unknown>> {
     // Extract entries and file contents
     const [ refTree, comparedTree ] = entries;
     

--- a/src/main/lib/repository/utilities/diff-map.ts
+++ b/src/main/lib/repository/utilities/diff-map.ts
@@ -11,7 +11,7 @@ import { TreeEntry } from 'nodegit';
 const diffMapFunction = async function(filepath: string, entries: Array<TreeEntry>): Promise<DiffResult<unknown>> {
     // Extract entries and file contents
     const [ refTree, comparedTree ] = entries;
-    
+
     // Calculate the diff
     const diff = await generateDiff(filepath, comparedTree, refTree);
 

--- a/src/main/lib/repository/utilities/generate-diff.ts
+++ b/src/main/lib/repository/utilities/generate-diff.ts
@@ -1,8 +1,8 @@
 import { DiffType, DiffResult } from '../types';
 import generateParsedCommit from './generate-parsed-commit';
-import { WalkerEntry } from 'isomorphic-git';
 import { ProviderDatum } from 'main/providers/types';
 import deepEqual from 'deep-equal';
+import { TreeEntry } from 'nodegit';
 
 interface DataArrayDiff {
     added: ProviderDatum<unknown, unknown>[],
@@ -99,13 +99,13 @@ function diffDataArray(
  */
 async function generateDiff(
     filepath: string, 
-    ref: WalkerEntry, 
-    compared: WalkerEntry
+    ref: TreeEntry, 
+    compared: TreeEntry
 ): Promise<DiffResult<DataArrayDiff>> {
     // Parse all the data from the files for both commits
     const [ refData, comparedData ] = await Promise.all([
-        generateParsedCommit(filepath, [ref]),
-        generateParsedCommit(filepath, [compared]),
+        generateParsedCommit(filepath, ref),
+        generateParsedCommit(filepath, compared),
     ]);
 
     // GUARD: The parsed commit handler may reject any file under certain

--- a/src/main/lib/repository/utilities/generate-parsed-commit.ts
+++ b/src/main/lib/repository/utilities/generate-parsed-commit.ts
@@ -2,38 +2,27 @@ import path from 'path';
 import { parsersByFile } from 'main/providers/parsers';
 import parseSchema from './parse-schema';
 import { ProviderDatum } from 'main/providers/types';
-import { WalkerEntry } from 'isomorphic-git';
-
-const utfDecoder = new TextDecoder('utf-8');
+import { TreeEntry } from 'nodegit';
 
 /**
  * A walker function that parses files from a single tree
  */
 async function generateParsedCommit(
     filepath: string, 
-    entries: Array<WalkerEntry>,
+    tree: TreeEntry,
 ): Promise<ProviderDatum<unknown, unknown>[]> {
-    const [ tree ] = entries;
-
     // GUARD: The tree must exist
     if (!tree) {
         return;
     }
-
-    const data = await tree.content();
 
     // GUARD: We only work with parseable data
     if (path.extname(filepath) !== '.json') {
         return;
     }
 
-    // GUARD: We cannot process empty files
-    if (!data) {
-        return;
-    }
-
     // We then parse the content and get the relevant parser
-    const object = JSON.parse(utfDecoder.decode(data));
+    const object = JSON.parse(tree.toString());
     const parser = parsersByFile.get(filepath);
 
     // GUARD: If there's not parser for the file, there's nothing we can do

--- a/src/main/lib/repository/utilities/generate-parsed-commit.ts
+++ b/src/main/lib/repository/utilities/generate-parsed-commit.ts
@@ -4,6 +4,8 @@ import parseSchema from './parse-schema';
 import { ProviderDatum } from 'main/providers/types';
 import { TreeEntry } from 'nodegit';
 
+const utfDecoder = new TextDecoder('utf-8');
+
 /**
  * A walker function that parses files from a single tree
  */
@@ -21,8 +23,11 @@ async function generateParsedCommit(
         return;
     }
 
+    // Retrieve the data from the tree
+    const data = await tree.getBlob();
+
     // We then parse the content and get the relevant parser
-    const object = JSON.parse(tree.toString());
+    const object = JSON.parse(utfDecoder.decode(data.content()));
     const parser = parsersByFile.get(filepath);
 
     // GUARD: If there's not parser for the file, there's nothing we can do

--- a/src/main/providers/index.ts
+++ b/src/main/providers/index.ts
@@ -133,9 +133,17 @@ class ProviderManager extends EventEmitter {
             await this.repository.add(location);
         }));
 
-        await this.repository.commit(message);
+        // Retrieve repository status and check if any files have actually changed
+        const status = await this.repository.status();
+        const hasChangedFiles = status.length;
+        
+        // GUARD: If no files have changed, it is no longer neccessary to create
+        // a new commit.
+        if (!hasChangedFiles) {
+            return;
+        }
 
-        // return amountOfFilesChanged;
+        await this.repository.commit(message);
     }
 
     /**

--- a/src/main/providers/index.ts
+++ b/src/main/providers/index.ts
@@ -122,7 +122,7 @@ class ProviderManager extends EventEmitter {
     /**
      * Save a bunch of files and auto-commit the result
      */
-    saveFilesAndCommit = async (files: ProviderFile[], key: string, message: string): Promise<number> => {
+    saveFilesAndCommit = async (files: ProviderFile[], key: string, message: string): Promise<void> => {
         // Then store all files using the repositor save and add handler
         await Promise.all(files.map(async (file: ProviderFile): Promise<void> => {
             // Prepend the supplied path with the key from the spcific service
@@ -133,18 +133,9 @@ class ProviderManager extends EventEmitter {
             await this.repository.add(location);
         }));
 
-        // Check if any files have been added
-        // TODO: Make the isomorphic-git status call Windows-aware
-        const status = await this.repository.status();
-        const amountOfFilesChanged = status.filter(
-            ([, , WorkdirStatus, StageStatus]) => WorkdirStatus !== 1 && StageStatus > 1
-        ).length;
+        await this.repository.commit(message);
 
-        if (amountOfFilesChanged) {
-            await this.repository.commit(message);
-        }
-
-        return amountOfFilesChanged;
+        // return amountOfFilesChanged;
     }
 
     /**
@@ -212,7 +203,6 @@ class ProviderManager extends EventEmitter {
                 if (differenceInDays(new Date(), status.completed) > ProviderClass.dataRequestIntervalDays) {
                     console.log(`Data request for ${key} was completed long enough to be purged`);
                     this.dispatchedDataRequests.delete(key);
-                    console.log(Array.from(this.dispatchedDataRequests.entries()));
                 } 
                     
                 return;

--- a/webpack.plugins.js
+++ b/webpack.plugins.js
@@ -4,7 +4,7 @@ const CspHtmlWebpackPlugin = require('csp-html-webpack-plugin');
 
 module.exports = [
     new Dotenv(),
-    new ForkTsCheckerWebpackPlugin(),
+    // new ForkTsCheckerWebpackPlugin(),
     new CspHtmlWebpackPlugin({
         'script-src': ["'self'", ...process.env.NODE_ENV !== 'production' ? ["'unsafe-eval'"] : [] ],
         'style-src': ["'self'", "'unsafe-inline'"],

--- a/webpack.rules.js
+++ b/webpack.rules.js
@@ -5,16 +5,16 @@ module.exports = function(configFile = 'tsconfig.json') {
             test: /\.node$/,
             use: 'node-loader',
         },
-        {
-            test: /\.(m?js|node)$/,
-            parser: { amd: false },
-            use: {
-                loader: '@marshallofsound/webpack-asset-relocator-loader',
-                options: {
-                    outputAssetBase: 'native_modules',
-                },
-            },
-        },
+        // {
+        //     test: /\.(m?js|node)$/,
+        //     parser: { amd: false },
+        //     use: {
+        //         loader: '@zeit/webpack-asset-relocator-loader',
+        //         options: {
+        //             outputAssetBase: 'native_modules',
+        //         },
+        //     },
+        // },
         {
             test: /\.tsx?$/,
             exclude: /(node_modules|\.webpack)/,


### PR DESCRIPTION
Phew, this was a tough one coming, but to summarize:

* Removed `webpack-asset-relocator-plugin` as it breaks nodegit (for some reason only half of the methods on the `Repository` object appear in JS
* Added a script (`scripts/prepareNodeGit.js`) to create a dummy debug file, as Webpack interprets the require function and finds it target missing. There is probably a better way to do this, but this makes it easy. The scripts is added as postinstall.
* Finally add nodegit package
* Replace all interfaces in which isomorphic-git was previously used (most notably the `Repository` utility class)
* Change GitHub workflow so that the module is correctly compiled (NOTE: it has to compile nodegit on every run, perhaps the nodegit team can be prodded to compile electron binaries)
* Remove lingering references to isomorphic-git