### PR TITLE
Add Spotify provider

### DIFF
--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -1,3 +1,7 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronDown } from 'app/assets/fa-light';
+import theme from 'app/styles/theme';
+import React, { useCallback } from 'react';
 import styled from 'styled-components';
 
 export const TextInput = styled.input`
@@ -18,3 +22,67 @@ export const Label = styled.label`
     flex-direction: column;
     color: #33333355;
 `;
+
+const Select = styled.select`
+    height: 50px;
+    padding: 16px;
+    border-radius: 4px;
+    border: 1px solid ${theme.colors.grey.medium};
+    color: black;
+    appearance: none;
+    width: 100%;
+    margin-bottom: 16px;
+
+    &:disabled {
+        background-color: ${theme.colors.grey.medium};
+        color: ${theme.colors.grey.dark};
+        cursor: not-allowed;
+    }
+`;
+
+const SelectContainer = styled.div`
+    position: relative;
+
+    svg {
+        position: absolute;
+        right: 16px;
+        top: 50%;
+        transform: translateY(-50%);
+    }
+`;
+
+interface DropdownProps {
+    label: string;
+    options: string[] | JSX.Element[] | Record<string, JSX.Element>;
+    value: string;
+    onSelect: (selectedValue: string) => void;
+    disabled?: boolean;
+}
+
+type Option = { key: string, value: unknown };
+
+export function Dropdown(props: DropdownProps): JSX.Element {
+    const { label, options, value, disabled, onSelect } = props;
+
+    const availableOptions: Option[] = Array.isArray(options)
+        ? options.map<Option>((o) => ({ key: o, value: o }))
+        : Object.keys(options).map((key) => ({ key, value: options[key] }));
+
+    const handleChange = useCallback((event) => {
+        onSelect(event.target.value);
+    }, [onSelect]);
+
+    return (
+        <Label>
+            {label}
+            <SelectContainer>
+                <Select value={value} disabled={disabled} onChange={handleChange}>
+                    {availableOptions.map(option =>
+                        <option key={option.key}>{option.value}</option>    
+                    )}
+                </Select>
+                <FontAwesomeIcon icon={faChevronDown} />
+            </SelectContainer>
+        </Label>
+    )
+}

--- a/src/app/components/PanelGrid.tsx
+++ b/src/app/components/PanelGrid.tsx
@@ -15,6 +15,7 @@ export const ListItem = styled.div`
 
 export const RowHeading = styled(ListItem)`
     border-bottom: 1px solid ${theme.colors.border};
+    background-color: #fbfbfb;
     font-weight: 400;
     position: sticky;
     top: 0;

--- a/src/app/components/Utility.tsx
+++ b/src/app/components/Utility.tsx
@@ -46,3 +46,10 @@ export const EmptyIcon = styled.span`
 export const MarginLeft = styled.span`
     margin-left: 1em;
 `;
+
+export const Ellipsis = styled.div`
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin-right: 5px;
+`;

--- a/src/app/screens/Data/styles.tsx
+++ b/src/app/screens/Data/styles.tsx
@@ -5,7 +5,7 @@ import theme from 'app/styles/theme';
 import DataType from 'app/utilities/DataType';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronRight, faMinus } from 'app/assets/fa-light';
-import { EmptyIcon } from 'app/components/Utility';
+import { Ellipsis, EmptyIcon } from 'app/components/Utility';
 import { useHistory } from 'react-router-dom';
 
 
@@ -120,7 +120,7 @@ export const ClickableDataPoint = ({ datum, type, index, ...props }: ClickableDa
     return (
         <ListButton onClick={handleClick} {...props}>
             <FontAwesomeIcon icon={DataType.getIcon(datum.type as ProvidedDataTypes)} fixedWidth style={{ marginRight: 8 }} />
-            {DataType.toString(datum)}
+            <Ellipsis>{DataType.toString(datum)}</Ellipsis>
             <FontAwesomeIcon icon={faChevronRight} style={{ marginLeft: 'auto', opacity: 0.5 }} />
         </ListButton>
     );

--- a/src/app/screens/Requests/components/NewAccountModal.tsx
+++ b/src/app/screens/Requests/components/NewAccountModal.tsx
@@ -15,10 +15,11 @@ type NewAccountProps = PropsWithChildren<{
     client: string, 
     onComplete: () => void,
     disabled?: boolean;
+    account?: string;
     selectedEmail?: string;
 }>;
 
-function NewAccountButton({ client, children, onComplete, ...props }: NewAccountProps): JSX.Element {
+function NewAccountButton({ client, children, onComplete, account, ...props }: NewAccountProps): JSX.Element {
     const [isActive, setActive] = useState(false);
     const dispatch = useAppDispatch();
 
@@ -76,7 +77,7 @@ function NewAccountModal(): JSX.Element {
                             <PullCenter>
                                 <NewAccountButton
                                     client={key}
-                                    emailAccount={selectedEmail}
+                                    account={availableProviders[key].requiresEmail ? selectedEmail : undefined}
                                     onComplete={closeModal}
                                     disabled={availableProviders[key].requiresEmail && selectedEmail === ''}
                                 >

--- a/src/app/screens/Requests/components/NewAccountModal.tsx
+++ b/src/app/screens/Requests/components/NewAccountModal.tsx
@@ -1,0 +1,67 @@
+import React, { PropsWithChildren, useCallback, useState } from 'react';
+import { faPlus } from 'app/assets/fa-light';
+import Button from 'app/components/Button';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Modal from 'app/components/Modal';
+import ModalMenu from 'app/components/Modal/Menu';
+import { PullContainer, MarginLeft, Margin, PullCenter } from 'app/components/Utility';
+import { addProviderAccount } from 'app/store/requests/actions';
+import { State, useAppDispatch } from 'app/store';
+import { useSelector } from 'react-redux';
+import Providers from 'app/utilities/Providers';
+
+type NewAccountProps = PropsWithChildren<{ 
+    client: string, 
+    onComplete: () => void,
+}>;
+
+function NewAccountButton({ client, children, onComplete, ...props }: NewAccountProps): JSX.Element {
+    const [isActive, setActive] = useState(false);
+    const dispatch = useAppDispatch();
+
+    // A handler for creating a new email account
+    const handleClick = useCallback(async () => {
+        // Set activity flag
+        setActive(true);
+
+        // Actually create a new account
+        await dispatch(addProviderAccount({ client }));
+
+        // Set new activity flag, and let parent component know we're done
+        setActive(false);
+        onComplete();
+    }, [dispatch, client, setActive])
+
+    return (
+        <Button icon={faPlus} {...props} onClick={handleClick} loading={isActive}>{children}</Button>
+    )
+}
+
+function NewAccountModal(): JSX.Element {
+    const availableProviders = useSelector((state: State) => state.requests.availableProviders);
+    const [modalIsOpen, setModal] = useState(false);
+    const openModal = useCallback(() => setModal(true), [setModal]);
+    const closeModal = useCallback(() => setModal(false), [setModal]);
+    
+    return (
+        <>
+            <Button fullWidth icon={faPlus} onClick={openModal}>
+                Add new account
+            </Button>
+            <Modal isOpen={modalIsOpen} onRequestClose={closeModal}>
+                <ModalMenu labels={availableProviders.map((key) =>
+                    <PullContainer verticalAlign key={key}><FontAwesomeIcon icon={Providers.getIcon(key)} /><MarginLeft>{key}</MarginLeft></PullContainer>
+                )}>
+                    {availableProviders.map((key) => (
+                        <Margin key={key}>
+                            <p>By adding a new account for {key}, you are able to retrieve your data from them.</p>
+                            <PullCenter><NewAccountButton client={key} onComplete={closeModal}>Add new account</NewAccountButton></PullCenter>
+                        </Margin>
+                    ))}
+                </ModalMenu>
+            </Modal>
+        </>
+    );
+}
+
+export default NewAccountModal;

--- a/src/app/screens/Requests/components/ProviderOverlay.tsx
+++ b/src/app/screens/Requests/components/ProviderOverlay.tsx
@@ -3,17 +3,19 @@ import { faCheck, faClock, faPlus, faQuestion } from 'app/assets/fa-light';
 import Button from 'app/components/Button';
 import RightSideOverlay, { Section } from 'app/components/RightSideOverlay';
 import { H2 } from 'app/components/Typography';
+import { State } from 'app/store';
 import Providers from 'app/utilities/Providers';
 import { formatDistanceToNow } from 'date-fns';
 import { DataRequestStatus } from 'main/providers/types';
 import React, { useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
 
 interface Props {
     selectedProvider: string;
-    status?: DataRequestStatus;
 }
 
-function ProviderOverlay({ selectedProvider, status }: Props): JSX.Element {
+function ProviderOverlay({ selectedProvider }: Props): JSX.Element {
+    const account = useSelector((state: State) => state.requests.byKey[selectedProvider]);
     const [isLoading, setLoading] = useState(false);
     const handleNewRequest = useCallback(async () => {
         setLoading(true);
@@ -28,10 +30,10 @@ function ProviderOverlay({ selectedProvider, status }: Props): JSX.Element {
                     <Section>
                         <H2>
                             <FontAwesomeIcon
-                                icon={Providers.getIcon(selectedProvider)}
+                                icon={Providers.getIcon(account.provider)}
                                 style={{ marginRight: 8 }}
                             />
-                            {selectedProvider}
+                            {account.account}
                         </H2>
                     </Section>
                     <Section>
@@ -41,15 +43,15 @@ function ProviderOverlay({ selectedProvider, status }: Props): JSX.Element {
                                 style={{ marginRight: 8 }}
                                 fixedWidth
                             />
-                            Data requested: <i>{status?.dispatched ? formatDistanceToNow(new Date(status.dispatched)) + ' ago' : 'never'}</i>
+                            Data requested: <i>{account.status?.dispatched ? formatDistanceToNow(new Date(account.status.dispatched)) + ' ago' : 'never'}</i>
                             <br />
                             <FontAwesomeIcon
                                 icon={faClock}
                                 style={{ marginRight: 8 }}
                                 fixedWidth
                             />
-                            Last check: <i>{status?.lastCheck ? formatDistanceToNow(new Date(status.lastCheck)) + ' ago' : 'never'}</i>
-                            {status?.completed && 
+                            Last check: <i>{account.status?.lastCheck ? formatDistanceToNow(new Date(account.status.lastCheck)) + ' ago' : 'never'}</i>
+                            {account.status?.completed && 
                                 <>
                                     <br />
                                     <FontAwesomeIcon
@@ -57,12 +59,12 @@ function ProviderOverlay({ selectedProvider, status }: Props): JSX.Element {
                                         style={{ marginRight: 8 }}
                                         fixedWidth
                                     />
-                                    Completed: <i>{formatDistanceToNow(new Date(status?.completed))} ago</i>
+                                    Completed: <i>{formatDistanceToNow(new Date(account.status?.completed))} ago</i>
                                 </>
                             }
                         </span>
                     </Section>
-                    {status?.dispatched ? 
+                    {account.status?.dispatched ? 
                         <Section>
                             <p>The data request you issued has not been completed yet. We&apos;ll let you know as soon as it&apos;s completed.</p>
                             <Button
@@ -82,7 +84,7 @@ function ProviderOverlay({ selectedProvider, status }: Props): JSX.Element {
                                 fullWidth
                                 icon={faPlus}
                                 onClick={handleNewRequest}
-                                disabled={!!status?.dispatched}
+                                disabled={!!account.status?.dispatched}
                                 loading={isLoading}
                             >
                                 Start Data Request

--- a/src/app/screens/Requests/index.tsx
+++ b/src/app/screens/Requests/index.tsx
@@ -63,7 +63,7 @@ function Requests(): JSX.Element {
                 </PanelBottomButtons>
             </SplitPanel>
             <List>
-                <ProviderOverlay selectedProvider={selectedProvider} status={map[selectedProvider]?.status} />
+                <ProviderOverlay selectedProvider={selectedProvider} />
             </List>
         </PanelGrid>
     )

--- a/src/app/screens/Requests/index.tsx
+++ b/src/app/screens/Requests/index.tsx
@@ -63,7 +63,7 @@ function Requests(): JSX.Element {
                 </PanelBottomButtons>
             </SplitPanel>
             <List>
-                <ProviderOverlay selectedProvider={selectedProvider} status={map[selectedProvider].status} />
+                <ProviderOverlay selectedProvider={selectedProvider} status={map[selectedProvider]?.status} />
             </List>
         </PanelGrid>
     )

--- a/src/app/screens/Requests/index.tsx
+++ b/src/app/screens/Requests/index.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 import { List, NavigatableListEntry, PanelBottomButtons, PanelGrid, RowHeading, SplitPanel, SubHeading } from 'app/components/PanelGrid';
-import Loading from 'app/components/Loading';
 import Providers from 'app/utilities/Providers';
 import { useParams } from 'react-router-dom';
 import { RouteProps } from '../types';
@@ -9,10 +8,11 @@ import getDescription from './getDescription';
 import styled from 'styled-components';
 import Button from 'app/components/Button';
 import { faSync } from 'app/assets/fa-light';
-import { useRequests } from 'app/store/requests/selectors';
+import { useAccounts } from 'app/store/requests/selectors';
 import { State, useAppDispatch } from 'app/store';
 import { useSelector } from 'react-redux';
 import { refreshRequests } from 'app/store/requests/actions';
+import NewAccountModal from './components/NewAccountModal';
 
 const StatusDescription = styled.span`
     font-size: 12px;
@@ -28,7 +28,7 @@ const Rows = styled.div`
 function Requests(): JSX.Element {
     const dispatch = useAppDispatch();
     const isLoadingRefresh = useSelector((state: State) => state.requests.isLoading.refresh);
-    const { providers, map } = useRequests();
+    const { accounts, map } = useAccounts();
     const { provider: selectedProvider } = useParams<RouteProps['requests']>();
 
     // Callback for refreshing all requests
@@ -40,29 +40,30 @@ function Requests(): JSX.Element {
                 <List>
                     <RowHeading>Your Accounts</RowHeading>
                     <SubHeading>Automated Requests</SubHeading>
-                    {providers.map(provider => 
+                    {accounts.map(account => 
                         <NavigatableListEntry
-                            key={provider}
-                            to={`/requests/${provider}`}
-                            icon={Providers.getIcon(provider)}
+                            key={account}
+                            to={`/requests/${account}`}
+                            icon={Providers.getIcon(map[account].provider)}
                             large
                         >
                             <Rows>
-                                <span>{provider}</span>
-                                <StatusDescription>{getDescription(map[provider])}</StatusDescription>
+                                <span>{map[account].account}</span>
+                                <StatusDescription>{getDescription(map[account].status)}</StatusDescription>
                             </Rows>
                         </NavigatableListEntry>
                     )}
                     <SubHeading>Email-based Requests</SubHeading>
                 </List>
                 <PanelBottomButtons>
+                    <NewAccountModal />
                     <Button fullWidth icon={faSync} loading={isLoadingRefresh} onClick={refresh}>
                         Refresh requests
                     </Button>
                 </PanelBottomButtons>
             </SplitPanel>
             <List>
-                <ProviderOverlay selectedProvider={selectedProvider} status={map[selectedProvider]} />
+                <ProviderOverlay selectedProvider={selectedProvider} status={map[selectedProvider].status} />
             </List>
         </PanelGrid>
     )

--- a/src/app/screens/Settings/email/components/NewAccountModal.tsx
+++ b/src/app/screens/Settings/email/components/NewAccountModal.tsx
@@ -6,7 +6,7 @@ import Modal from 'app/components/Modal';
 import ModalMenu from 'app/components/Modal/Menu';
 import { Margin, MarginLeft, PullCenter, PullContainer } from 'app/components/Utility';
 import { useAppDispatch } from 'app/store';
-import { createNewAccount } from 'app/store/email/actions';
+import { createEmailAccount } from 'app/store/email/actions';
 import React, { PropsWithChildren, useCallback, useState } from 'react';
 
 type NewAccountProps = PropsWithChildren<{ 
@@ -24,7 +24,7 @@ function NewAccountButton({ client, children, onComplete, ...props }: NewAccount
         setActive(true);
 
         // Actually create a new account
-        await dispatch(createNewAccount(client));
+        await dispatch(createEmailAccount(client));
 
         // Set new activity flag, and let parent component know we're done
         setActive(false);

--- a/src/app/screens/Timeline/components/Diff.tsx
+++ b/src/app/screens/Timeline/components/Diff.tsx
@@ -84,16 +84,18 @@ class Diff extends PureComponent<Props, State> {
         const diff = this.props.diff || this.state.diff;
         const { commit } = this.props;
 
+        console.log(diff);
+
         if (!diff) {
             return (
-                <RightSideOverlay columnPosition={2}>
+                <RightSideOverlay>
                     <Loading />
                 </RightSideOverlay>
             );
         }
 
         return (
-            <RightSideOverlay columnPosition={2}>
+            <RightSideOverlay>
                 <>
                     <Section>
                         <H2>

--- a/src/app/store/email/actions.ts
+++ b/src/app/store/email/actions.ts
@@ -1,17 +1,17 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import Email from 'app/utilities/Email';
 
-export const fetchAccounts = createAsyncThunk(
+export const fetchEmailAccounts = createAsyncThunk(
     'email/accounts/fetch',
     () => Email.getAccounts()
 );
 
-export const fetchClients = createAsyncThunk(
+export const fetchEmailClients = createAsyncThunk(
     'email/clients/fetch',
     () => Email.getClients()
 );
 
-export const createNewAccount = createAsyncThunk(
+export const createEmailAccount = createAsyncThunk(
     'email/accounts/create',
     (client: string) => Email.initialise(client)
 );

--- a/src/app/store/email/index.ts
+++ b/src/app/store/email/index.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { createNewAccount, fetchAccounts, fetchClients } from './actions';
+import { createEmailAccount, fetchEmailAccounts, fetchEmailClients } from './actions';
 
 interface EmailState {
     clients: string[];
@@ -28,15 +28,15 @@ const emailSlice = createSlice({
     initialState,
     reducers: {},
     extraReducers: builder => {
-        builder.addCase(fetchAccounts.fulfilled, (state, action) => {
+        builder.addCase(fetchEmailAccounts.fulfilled, (state, action) => {
             state.accounts.byId = action.payload;
             state.accounts.all = Object.keys(action.payload);
         });
-        builder.addCase(fetchClients.fulfilled, (state, action) => {
+        builder.addCase(fetchEmailClients.fulfilled, (state, action) => {
             state.clients = action.payload;
         });
-        builder.addCase(createNewAccount.pending, (state) => { state.isLoading.newAccount = true })
-        builder.addCase(createNewAccount.fulfilled, (state) => { state.isLoading.newAccount = false })
+        builder.addCase(createEmailAccount.pending, (state) => { state.isLoading.newAccount = true })
+        builder.addCase(createEmailAccount.fulfilled, (state) => { state.isLoading.newAccount = false })
     }
 });
 

--- a/src/app/store/email/selectors.ts
+++ b/src/app/store/email/selectors.ts
@@ -1,7 +1,7 @@
 import Email from 'app/utilities/Email';
 import { useCallback, useEffect } from 'react';
 import { useAppDispatch } from '..';
-import { fetchAccounts } from './actions';
+import { fetchEmailAccounts } from './actions';
 
 /**
  * A helper that keeps the providers up-to-date in Redux
@@ -12,7 +12,7 @@ export function EmailSubscription(): null {
     // Callback that fetched all requests
     const refreshAccounts = useCallback(() => {
         console.log('Received email update event');
-        dispatch(fetchAccounts());
+        dispatch(fetchEmailAccounts());
     }, [dispatch]);
 
     useEffect(() => {

--- a/src/app/store/index.ts
+++ b/src/app/store/index.ts
@@ -38,7 +38,7 @@ export type State = ReturnType<typeof rootReducer>;
 const persistConfig: PersistConfig<State> = {
     key: 'app_store',
     storage: ElectronStorage(),
-    version: 5,
+    version: 6,
     migrate: createMigrate(migrations),
     serialize: false,
     deserialize: false,

--- a/src/app/store/migrations.ts
+++ b/src/app/store/migrations.ts
@@ -11,6 +11,17 @@ const migrations: MigrationManifest = {
             telemetry: state.telemetry,
             newCommits: state.newCommit || [],
         }
+    },
+    6: (state) => {
+        return {
+            ...state,
+            requests: {
+                availableProviders: [],
+                all: [],
+                byKey: {},
+                isLoading: state.requests.isLoading,
+            }
+        }
     }
 }
 

--- a/src/app/store/requests/actions.ts
+++ b/src/app/store/requests/actions.ts
@@ -17,7 +17,7 @@ export const refreshRequests = createAsyncThunk(
 export const addProviderAccount = createAsyncThunk(
     'requests/new-account',
     ({ client, account }: { client: string, account?: string }, { dispatch }) => {
-        const value = Providers.initialise(client);
+        const value = Providers.initialise(client, account);
         dispatch(fetchProviderAccounts());
         return value;
     }

--- a/src/app/store/requests/actions.ts
+++ b/src/app/store/requests/actions.ts
@@ -1,15 +1,29 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import Providers from 'app/utilities/Providers';
 
-export const fetchRequests = createAsyncThunk(
-    'requests/fetch',
-    () => Providers.getDataRequests()
+export const fetchProviderAccounts = createAsyncThunk(
+    'requests/fetch/accounts',
+    () => Providers.getAccounts()
 )
 
 export const refreshRequests = createAsyncThunk(
     'requests/refresh',
     async (arg, { dispatch }) => {
         await Providers.refresh();
-        await dispatch(fetchRequests());
+        await dispatch(fetchProviderAccounts());
     }
+)
+
+export const addProviderAccount = createAsyncThunk(
+    'requests/new-account',
+    ({ client, account }: { client: string, account?: string }, { dispatch }) => {
+        const value = Providers.initialise(client);
+        dispatch(fetchProviderAccounts());
+        return value;
+    }
+)
+
+export const fetchAvailableProviders = createAsyncThunk(
+    'requests/fetch/providers',
+    () => Providers.getAvailableProviders(),
 )

--- a/src/app/store/requests/index.ts
+++ b/src/app/store/requests/index.ts
@@ -5,7 +5,8 @@ import { fetchAvailableProviders, fetchProviderAccounts, refreshRequests } from 
 interface RequestsState {
     byKey: Record<string, InitialisedProvider>;
     all: string[];
-    availableProviders: string[];
+    allProviders: string[];
+    availableProviders: Record<string, { requiresEmail: boolean }>;
     isLoading: {
         requests: boolean;
         refresh: boolean;
@@ -15,7 +16,8 @@ interface RequestsState {
 const initialState: RequestsState = {
     byKey: {},
     all: [],
-    availableProviders: [],
+    allProviders: [],
+    availableProviders: {},
     isLoading: {
         requests: false,
         refresh: false,
@@ -39,6 +41,7 @@ const requestsSlice = createSlice({
         });
         builder.addCase(fetchAvailableProviders.fulfilled, (state, action) => {
             console.log(action);
+            state.allProviders = Object.keys(action.payload);
             state.availableProviders = action.payload;
         });
     }

--- a/src/app/store/requests/index.ts
+++ b/src/app/store/requests/index.ts
@@ -1,10 +1,11 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { DataRequestStatus } from 'main/providers/types';
-import { fetchRequests, refreshRequests } from './actions';
+import { InitialisedProvider } from 'main/providers/types';
+import { fetchAvailableProviders, fetchProviderAccounts, refreshRequests } from './actions';
 
 interface RequestsState {
-    byKey: Record<string, DataRequestStatus>;
-    allKeys: string[];
+    byKey: Record<string, InitialisedProvider>;
+    all: string[];
+    availableProviders: string[];
     isLoading: {
         requests: boolean;
         refresh: boolean;
@@ -13,7 +14,8 @@ interface RequestsState {
 
 const initialState: RequestsState = {
     byKey: {},
-    allKeys: [],
+    all: [],
+    availableProviders: [],
     isLoading: {
         requests: false,
         refresh: false,
@@ -28,12 +30,16 @@ const requestsSlice = createSlice({
         builder.addCase(refreshRequests.pending, state => { state.isLoading.refresh = true });
         builder.addCase(refreshRequests.rejected, state => { state.isLoading.refresh = false });
         builder.addCase(refreshRequests.fulfilled, state => { state.isLoading.refresh = false });
-        builder.addCase(fetchRequests.pending, state => { state.isLoading.requests = true });
-        builder.addCase(fetchRequests.rejected, state => { state.isLoading.requests = false });
-        builder.addCase(fetchRequests.fulfilled, (state, action) => { 
+        builder.addCase(fetchProviderAccounts.pending, state => { state.isLoading.requests = true });
+        builder.addCase(fetchProviderAccounts.rejected, state => { state.isLoading.requests = false });
+        builder.addCase(fetchProviderAccounts.fulfilled, (state, action) => { 
             state.isLoading.requests = false;
-            state.byKey = action.payload.dispatched;
-            state.allKeys = action.payload.providers;
+            state.byKey = action.payload.accounts;
+            state.all = Object.keys(action.payload.accounts);
+        });
+        builder.addCase(fetchAvailableProviders.fulfilled, (state, action) => {
+            console.log(action);
+            state.availableProviders = action.payload;
         });
     }
 });

--- a/src/app/store/requests/selectors.ts
+++ b/src/app/store/requests/selectors.ts
@@ -1,12 +1,12 @@
 import Providers from 'app/utilities/Providers';
-import { DataRequestStatus } from 'main/providers/types';
+import { InitialisedProvider } from 'main/providers/types';
 import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { State, useAppDispatch } from '..';
-import { fetchRequests } from './actions';
+import { fetchAvailableProviders, fetchProviderAccounts } from './actions';
 
 type RequestState = {
-    providers: State['requests']['allKeys']
+    accounts: State['requests']['all']
     map: State['requests']['byKey']
     isLoading: State['requests']['isLoading']['requests'];
 }
@@ -14,11 +14,11 @@ type RequestState = {
 /**
  * Retrieve all currently active requests
  */
-export function useRequests(): RequestState {
+export function useAccounts(): RequestState {
     const requests = useSelector((state: State) => state.requests);
 
     return {
-        providers: requests.allKeys,
+        accounts: requests.all,
         map: requests.byKey,
         isLoading: requests.isLoading.requests,
     };
@@ -28,7 +28,7 @@ export function useRequests(): RequestState {
  * Retrieve a single provider by key name
  * @param key Provider key
  */
-export function useProvider(key: string): DataRequestStatus {
+export function useProvider(key: string): InitialisedProvider {
     return useSelector((state: State) => state.requests.byKey[key]);
 }
 
@@ -40,7 +40,8 @@ export function ProviderSubscription(): null {
 
     // Callback that fetched all requests
     const refreshProviders = useCallback(() => {
-        dispatch(fetchRequests());
+        dispatch(fetchProviderAccounts());
+        dispatch(fetchAvailableProviders());
     }, [dispatch]);
 
     useEffect(() => {

--- a/src/app/styles/theme.ts
+++ b/src/app/styles/theme.ts
@@ -1,7 +1,7 @@
 const theme = {
     colors: {
         blue: {
-            primary: '#296BFF',
+            primary: '#0000FF',
             light: '#78BDFF',
             veryLight: '#BAD7FF',
             dark: '#00186E',

--- a/src/app/utilities/DataType.tsx
+++ b/src/app/utilities/DataType.tsx
@@ -7,7 +7,7 @@ import {
     PrivacySetting,
     LoginInstance,
     ProfilePicture,
-    Session, Employment, EventResponse, VisitedPage, OffSiteActivity, EducationExperience, MobileDevice, RegistrationDate
+    Session, Employment, EventResponse, VisitedPage, OffSiteActivity, EducationExperience, MobileDevice, RegistrationDate, PlayedSong
 } from 'main/providers/types';
 import {
     IconDefinition,
@@ -51,7 +51,9 @@ import {
     faClock,
     faUniversity,
     faUserPlus,
-    faMobile
+    faMobile,
+    faMusic,
+    faRobot
 } from 'app/assets/fa-light';
 
 class DataType {
@@ -149,6 +151,10 @@ class DataType {
                 return faUserPlus;
             case ProvidedDataTypes.MOBILE_DEVICE:
                 return faMobile;
+            case ProvidedDataTypes.PLAYED_SONG:
+                return faMusic;
+            case ProvidedDataTypes.INFERENCE:
+                return faRobot;
             default:
                 return faSquare;
         }
@@ -216,6 +222,10 @@ class DataType {
                 const { data: registrationDate } = datum as RegistrationDate;
                 return registrationDate.toLocaleString();
             }
+            case ProvidedDataTypes.PLAYED_SONG: {
+                const { data: { track, artist } } = datum as PlayedSong;
+                return `${artist} - ${track}`;
+            }
             case ProvidedDataTypes.EMAIL:
             case ProvidedDataTypes.FIRST_NAME:
             case ProvidedDataTypes.LAST_NAME:
@@ -238,6 +248,7 @@ class DataType {
             case ProvidedDataTypes.GENDER:
             case ProvidedDataTypes.SEARCH_QUERY:
             case ProvidedDataTypes.POST_SEEN:
+            case ProvidedDataTypes.INFERENCE:
             default:
                 return datum.data as string;
         }

--- a/src/app/utilities/Providers.ts
+++ b/src/app/utilities/Providers.ts
@@ -21,8 +21,8 @@ class Providers {
         window.api.removeListener(channel, handler);
     }
 
-    static initialise(key: string): Promise<boolean> {
-        return window.api.invoke(channel, ProviderCommands.INITIALISE, key);
+    static initialise(key: string, account?: string): Promise<boolean> {
+        return window.api.invoke(channel, ProviderCommands.INITIALISE, key, account);
     }
 
     static update(key: string): Promise<void> {
@@ -49,7 +49,7 @@ class Providers {
         return window.api.invoke(channel, ProviderCommands.GET_ACCOUNTS);
     }
 
-    static getAvailableProviders(): Promise<string[]> {
+    static getAvailableProviders(): Promise<Record<string, { requiresEmail: boolean }>> {
         return window.api.invoke(channel, ProviderCommands.GET_AVAILABLE_PROVIDERS);
     }
 

--- a/src/app/utilities/Providers.ts
+++ b/src/app/utilities/Providers.ts
@@ -1,5 +1,5 @@
 import { ProviderCommands, ProviderEvents, DataRequestStatus } from 'main/providers/types';
-import { faFacebookF, faInstagram, faLinkedinIn, IconDefinition } from '@fortawesome/free-brands-svg-icons';
+import { faFacebookF, faInstagram, faLinkedinIn, faSpotify, IconDefinition } from '@fortawesome/free-brands-svg-icons';
 import { faSquare } from 'app/assets/fa-light';
 import { IpcRendererEvent } from 'electron';
 
@@ -58,6 +58,8 @@ class Providers {
                 return faFacebookF;
             case 'linkedin':
                 return faLinkedinIn;
+            case 'spotify':
+                return faSpotify;
             default:
                 return faSquare;
         }

--- a/src/app/utilities/Providers.ts
+++ b/src/app/utilities/Providers.ts
@@ -1,4 +1,4 @@
-import { ProviderCommands, ProviderEvents, DataRequestStatus } from 'main/providers/types';
+import { ProviderCommands, ProviderEvents, InitialisedProvider } from 'main/providers/types';
 import { faFacebookF, faInstagram, faLinkedinIn, faSpotify, IconDefinition } from '@fortawesome/free-brands-svg-icons';
 import { faSquare } from 'app/assets/fa-light';
 import { IpcRendererEvent } from 'electron';
@@ -6,9 +6,8 @@ import { IpcRendererEvent } from 'electron';
 const channel = 'providers';
 
 type DataRequestReturnType = {
-    dispatched: Record<string, DataRequestStatus>;
     lastChecked: Date;
-    providers: string[];
+    accounts: Record<string, InitialisedProvider>;
 }
 
 type SubscriptionHandler = (event: IpcRendererEvent, type: ProviderEvents) => void;
@@ -46,8 +45,12 @@ class Providers {
         return window.api.invoke(channel, ProviderCommands.REFRESH);
     }
 
-    static getDataRequests(): Promise<DataRequestReturnType> {
-        return window.api.invoke(channel, ProviderCommands.GET_DISPATCHED_DATA_REQUESTS);
+    static getAccounts(): Promise<DataRequestReturnType> {
+        return window.api.invoke(channel, ProviderCommands.GET_ACCOUNTS);
+    }
+
+    static getAvailableProviders(): Promise<string[]> {
+        return window.api.invoke(channel, ProviderCommands.GET_AVAILABLE_PROVIDERS);
     }
 
     static getIcon(key: string): IconDefinition {

--- a/src/main/email-client/gmail/index.ts
+++ b/src/main/email-client/gmail/index.ts
@@ -174,8 +174,8 @@ export default class GmailEmailClient implements EmailClient {
      * If so, the access token has expired. It will fetch a new one and mount a
      * new request to continue the chain.
      */
-    tokenMiddleware(url: string, init: RequestInit = null): ((response: Response) => Promise<Response>) {
-        return async function(response: Response): Promise<Response> {
+    tokenMiddleware = (url: string, init: RequestInit = null): ((response: Response) => Promise<Response>) => {
+        return async (response: Response): Promise<Response> => {
             // GUARD: Check if the token has expired
             if (response.status === 401) {
                 // If so, refresh the token

--- a/src/main/initialise.ts
+++ b/src/main/initialise.ts
@@ -23,8 +23,6 @@ function initialise(): void {
         // And also inject this into its respective bridge
         new ProviderBridge(providerManager);
     });
-
-
 }
 
 export default initialise;

--- a/src/main/lib/create-secure-window.ts
+++ b/src/main/lib/create-secure-window.ts
@@ -75,12 +75,14 @@ export function withSecureWindow<U>(
     // Create a Promise that inspects the window 'close' event, and rejects if
     // it is ever called.
     const closePromise = new Promise((resolve, reject) => {
-        window.on('close', () => reject(new Error('UserAbort')));
+        window.on('close', () => reject(new Error('SecureWindowUserAbort')));
     });
 
     // Create a timeout promise, in order to ensure we don't leavy any zombie
     // windows open in the background
-    const timeoutPromise = new Promise(resolve => setTimeout(resolve, 120_000));
+    const timeoutPromise = new Promise((resolve, reject) => {
+        setTimeout(() => reject(new Error('SecureWindowTimeout')), 120_000);
+    });
 
     // Race the function against the other promises, so that the whole function is
     // rejected if the window is ever closed or encounters the timeout.

--- a/src/main/lib/create-secure-window.ts
+++ b/src/main/lib/create-secure-window.ts
@@ -2,7 +2,7 @@ import { BrowserWindow } from 'electron';
 import { URL } from 'url';
 import crypto from 'crypto';
 
-interface Params {
+export interface SecureWindowParameters {
     key?: string;
     origin: string;
     options?: Electron.BrowserWindowConstructorOptions;
@@ -16,7 +16,7 @@ interface Params {
  * @param options An optional options object that should be passed to the
  * BrowserWindow constructor. This may not contain webPreferences
  */
-function createSecureWindow(params: Params): BrowserWindow {
+function createSecureWindow(params: SecureWindowParameters): BrowserWindow {
     const { key, origin, options = {} } = params;
 
     // GUARD: webPreferences are off-limits
@@ -66,7 +66,7 @@ function createSecureWindow(params: Params): BrowserWindow {
  * @param fn The function that needs the window object
  */
 export function withSecureWindow<U>(
-    params: Params,
+    params: SecureWindowParameters,
     fn: (window: BrowserWindow) => Promise<U>,
 ): Promise<U> {
     // Create new Window with the given parameters

--- a/src/main/lib/repository/utilities/generate-parsed-commit.ts
+++ b/src/main/lib/repository/utilities/generate-parsed-commit.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { parsersByFile } from 'main/providers/parsers';
+import { getParserByFileName } from 'main/providers/parsers';
 import parseSchema from './parse-schema';
 import { ProviderDatum } from 'main/providers/types';
 import { Blob, TreeEntry } from 'nodegit';
@@ -55,8 +55,8 @@ async function generateParsedCommit(
     }
     
     // We then parse the content and get the relevant parser
-    const parser = parsersByFile.get(filepath);
-    
+    const parser = getParserByFileName(filepath);
+
     // GUARD: If there's not parser for the file, there's nothing we can do
     if (!parser) {
         return;

--- a/src/main/lib/repository/utilities/parse-schema.ts
+++ b/src/main/lib/repository/utilities/parse-schema.ts
@@ -39,7 +39,13 @@ function recursivelyExtractData(haystack: {[key: string]: any}, needle: string |
         if (Array.isArray(needle)
             ? needle.includes(key)
             : key === needle) {
-            data.push(item);
+            // GUARD: Double-check if item contains valid date
+            if (item) {
+                // Make sure to unpack any arrays that come along
+                data.push(...(Array.isArray(item) ? item : [item]));
+            }
+            
+            // Exit the loop
             break;
         }
 

--- a/src/main/providers/bridge.ts
+++ b/src/main/providers/bridge.ts
@@ -43,7 +43,7 @@ class ProviderBridge {
                 return availableProviders.map((Client) => Client.key);
             case ProviderCommands.GET_ACCOUNTS:
                 return {
-                    lastChecked: this.providers.lastDataRequestCheck.toString(),
+                    lastChecked: this.providers.lastDataRequestCheck?.toString(),
                     accounts: Object.fromEntries(this.providers.accounts),
                 };
         }

--- a/src/main/providers/bridge.ts
+++ b/src/main/providers/bridge.ts
@@ -1,4 +1,4 @@
-import Repository from '.';
+import Providers, { providers as availableProviders }  from '.';
 import { ProviderCommands, ProviderEvents } from './types';
 import { ipcMain, IpcMainInvokeEvent } from 'electron';
 import WindowStore from 'main/lib/window-store';
@@ -6,13 +6,13 @@ import WindowStore from 'main/lib/window-store';
 const channelName = 'providers';
 
 class ProviderBridge {
-    repository: Repository = null;
+    providers: Providers = null;
 
     messageCache: [IpcMainInvokeEvent, number][] = [];
 
-    constructor(repository: Repository) {
-        this.repository = repository;
-        this.repository.on('ready', this.clearMessageCache);
+    constructor(providers: Providers) {
+        this.providers = providers;
+        this.providers.on('ready', this.clearMessageCache);
 
         ipcMain.handle(channelName, this.handleMessage);
     }
@@ -21,29 +21,30 @@ class ProviderBridge {
     private handleMessage = async (event: IpcMainInvokeEvent, command: number, ...args: any[]): Promise<any> => {
         // GUARD: Check if the repository is initialised. If not, defer to the
         // messagecache, so that it can be injected later.
-        if (!this.repository.isInitialised) {
+        if (!this.providers.isInitialised) {
             this.messageCache.push([event, command]);
             return;
         }
         
         switch(command) {
             case ProviderCommands.INITIALISE:
-                return this.repository.initialise(args[0]);
+                return this.providers.initialise(args[0]);
             case ProviderCommands.UPDATE:
-                return this.repository.update(args[0]);
+                return this.providers.update(args[0]);
             case ProviderCommands.UPDATE_ALL:
-                return this.repository.updateAll();
+                return this.providers.updateAll();
             case ProviderCommands.DISPATCH_DATA_REQUEST:
-                return this.repository.dispatchDataRequest(args[0]);
+                return this.providers.dispatchDataRequest(args[0]);
             case ProviderCommands.DISPATCH_DATA_REQUEST_TO_ALL:
-                return this.repository.dispatchDataRequestToAll();
+                return this.providers.dispatchDataRequestToAll();
             case ProviderCommands.REFRESH:
-                return this.repository.refresh();
-            case ProviderCommands.GET_DISPATCHED_DATA_REQUESTS:
+                return this.providers.refresh();
+            case ProviderCommands.GET_AVAILABLE_PROVIDERS:
+                return availableProviders.map((Client) => Client.key);
+            case ProviderCommands.GET_ACCOUNTS:
                 return {
-                    dispatched: Object.fromEntries(this.repository.dispatchedDataRequests), 
-                    lastChecked: this.repository.lastDataRequestCheck.toString(),
-                    providers: Array.from(this.repository.instances.keys()),
+                    lastChecked: this.providers.lastDataRequestCheck.toString(),
+                    accounts: Object.fromEntries(this.providers.accounts),
                 };
         }
     }

--- a/src/main/providers/bridge.ts
+++ b/src/main/providers/bridge.ts
@@ -28,7 +28,7 @@ class ProviderBridge {
         
         switch(command) {
             case ProviderCommands.INITIALISE:
-                return this.providers.initialise(args[0]);
+                return this.providers.initialise(args[0], args[1]);
             case ProviderCommands.UPDATE:
                 return this.providers.update(args[0]);
             case ProviderCommands.UPDATE_ALL:
@@ -40,7 +40,12 @@ class ProviderBridge {
             case ProviderCommands.REFRESH:
                 return this.providers.refresh();
             case ProviderCommands.GET_AVAILABLE_PROVIDERS:
-                return availableProviders.map((Client) => Client.key);
+                return availableProviders.reduce<Record<string, { requiresEmail: boolean}>>((sum, Client) => {
+                    sum[Client.key] = {
+                        requiresEmail: Object.getPrototypeOf(Client).name === 'EmailDataRequestProvider'
+                    }
+                    return sum;
+                }, {});
             case ProviderCommands.GET_ACCOUNTS:
                 return {
                     lastChecked: this.providers.lastDataRequestCheck?.toString(),

--- a/src/main/providers/facebook/index.ts
+++ b/src/main/providers/facebook/index.ts
@@ -15,11 +15,12 @@ const requestSavePath = path.join(app.getAppPath(), 'data');
 class Facebook extends DataRequestProvider {
     public static key = 'facebook';
     public static dataRequestIntervalDays = 5;
+    public static requiresEmailAccount = false;
 
-    async initialise(): Promise<boolean> {
+    async initialise(): Promise<string> {
         await this.verifyLoggedInStatus();
 
-        return true;
+        return '';
     }
 
     verifyLoggedInStatus = async (): Promise<Electron.Cookie[]> => {

--- a/src/main/providers/index.ts
+++ b/src/main/providers/index.ts
@@ -309,7 +309,7 @@ class ProviderManager extends EventEmitter {
                 console.log('A data request has completed! Starting to parse...')
 
                 // If it is complete now, we'll fetch the data and parse it
-                const dirPath = path.join(REPOSITORY_PATH, key);
+                const dirPath = path.join(REPOSITORY_PATH, account.provider, account.account);
                 const files = await instance.parseDataRequest(dirPath);
                 const changedFiles = await this.saveFilesAndCommit(files, key, `Data Request [${key}] ${new Date().toLocaleString()}`, ProviderUpdateType.DATA_REQUEST);
                 Notifications.success(`The data request for ${key} was successfully completed. ${changedFiles} files were changed.`);

--- a/src/main/providers/index.ts
+++ b/src/main/providers/index.ts
@@ -105,6 +105,7 @@ class ProviderManager extends EventEmitter {
      * @param key 
      */
     initialise = async (provider: string, accountName?: string): Promise<string> => {
+        console.log(`Attempting to initialise a new ${provider} (${accountName})`);
         // Generate a random string that is used to refer to the sessions for
         // this particular account
         const windowKey = crypto.randomBytes(32).toString('hex');

--- a/src/main/providers/index.ts
+++ b/src/main/providers/index.ts
@@ -59,7 +59,7 @@ class ProviderManager extends EventEmitter {
 
         // Then create instances for each provider that is retrieved from the store
         this.accounts.forEach((account, key) => {
-            const Provider = mapProviderToKey[key];
+            const Provider = mapProviderToKey[account.provider];
             this.instances.set(key, new Provider(account.windowKey, account.account));
         });
 
@@ -166,11 +166,12 @@ class ProviderManager extends EventEmitter {
         updateType: ProviderUpdateType
     ): Promise<number> => {
         console.log(`Saving and committing files for ${key}...`);
+        const account = this.accounts.get(key);
 
         // Then store all files using the repositor save and add handler
         await Promise.all(files.map(async (file: ProviderFile): Promise<void> => {
-            // Prepend the supplied path with the key from the spcific service
-            const location = `${key}/${file.filepath}`;
+            // Prepend the supplied path with the key from the specific service
+            const location = `${account.provider}/${account.account}/${file.filepath}`;
 
             // Save the files to disk, and add the files
             if (file.data) {
@@ -196,7 +197,8 @@ class ProviderManager extends EventEmitter {
 
         // Gather the set of data that is to be appended to the commit
         const messageData: Record<string, string> = {
-            'Aeon-Provider': key,
+            'Aeon-Provider': account.provider,
+            'Aeon-Account': account.account,
             'Aeon-Update-Type': updateType,
         }
 

--- a/src/main/providers/index.ts
+++ b/src/main/providers/index.ts
@@ -10,12 +10,14 @@ import store from 'main/store';
 import path from 'path';
 import Facebook from './facebook';
 import LinkedIn from './linkedin';
+import Spotify from './spotify';
 import EmailManager from 'main/email-client';
 
 const providers: Array<typeof Provider | typeof DataRequestProvider> = [
     Instagram,
     Facebook,
     LinkedIn,
+    Spotify,
 ];
 
 class ProviderManager extends EventEmitter {

--- a/src/main/providers/index.ts
+++ b/src/main/providers/index.ts
@@ -103,6 +103,11 @@ class ProviderManager extends EventEmitter {
         const instance = new mapProviderToKey[provider](windowKey);
         const account = await instance.initialise();
 
+        // GUARD: Check if the instance has correctly returned an account name
+        if (!account) {
+            throw new Error('Initialising provider did not return account name');
+        }
+
         // Save the key to the accounts array
         const key = `${provider}_${account}`;
         this.accounts.set(key, {
@@ -275,6 +280,12 @@ class ProviderManager extends EventEmitter {
             // GUARD: If we cannot find an instance for this provider type, we
             // skip it
             if (!instance) {
+                return;
+            }
+
+            // GUARD: If there is not active request for this account, we don't
+            // need to force it
+            if (!account.status.dispatched) {
                 return;
             }
 

--- a/src/main/providers/instagram/index.ts
+++ b/src/main/providers/instagram/index.ts
@@ -153,12 +153,9 @@ class Instagram extends DataRequestProvider {
             // password. We then listen for a succesfull AJAX call 
             return new Promise((resolve) => {
                 window.webContents.session.webRequest.onCompleted({
-                    urls: [ 'https://*.facebook.com/*' ]
+                    urls: [ 'https://www.instagram.com/download/request_download_data_ajax/' ]
                 }, (details: Electron.OnCompletedListenerDetails) => {
-                    console.log('NEW REQUEST', details);
-
-                    if (details.url.endsWith('www.instagram.com%2Fdownload%2Frequest%2F&sdk=joey&wants_cookie_data=true')
-                        && details.statusCode === 200) {
+                    if (details.statusCode === 200) {
                         resolve();
                     }
                 });

--- a/src/main/providers/linkedin/index.ts
+++ b/src/main/providers/linkedin/index.ts
@@ -15,11 +15,12 @@ const requestSavePath = path.join(app.getAppPath(), 'data');
 class LinkedIn extends DataRequestProvider {
     public static key = 'linkedin';
     public static dataRequestIntervalDays = 14;
+    public static requiresEmailAccount = false;
 
-    async initialise(): Promise<boolean> {
+    async initialise(): Promise<string> {
         await this.verifyLoggedInStatus();
 
-        return true;
+        return '';
     }
 
     verifyLoggedInStatus = async (): Promise<Electron.Cookie[]> => {

--- a/src/main/providers/linkedin/index.ts
+++ b/src/main/providers/linkedin/index.ts
@@ -5,11 +5,6 @@ import path from 'path';
 import fs from 'fs';
 import AdmZip from 'adm-zip';
 
-const windowParams = {
-    key: 'linkedin',
-    origin: 'linkedin.com',
-};
-
 const requestSavePath = path.join(app.getAppPath(), 'data');
 
 class LinkedIn extends DataRequestProvider {
@@ -17,14 +12,33 @@ class LinkedIn extends DataRequestProvider {
     public static dataRequestIntervalDays = 14;
     public static requiresEmailAccount = false;
 
+    /**
+     * The parameters to be stored for the secure windows
+     */
+    windowParams = {
+        key: this.windowKey,
+        origin: 'linkedin.com',
+    };
+
     async initialise(): Promise<string> {
         await this.verifyLoggedInStatus();
+        return this.getAccountName();
+    }
 
-        return '';
+    getAccountName = async(): Promise<string> => {
+        return withSecureWindow<string>(this.windowParams, async (window) => {
+            // Go to /me and wait for LinkedIn to redirect
+            await window.loadURL('https://www.linkedin.com/psettings/email');
+
+            // Then steal the accountname from the URL
+            return window.webContents.executeJavaScript(`
+                document.querySelector('.email-container p.email-address').textContent
+            `);
+        });
     }
 
     verifyLoggedInStatus = async (): Promise<Electron.Cookie[]> => {
-        return withSecureWindow<Electron.Cookie[]>(windowParams, (window) => {
+        return withSecureWindow<Electron.Cookie[]>(this.windowParams, (window) => {
             const settingsUrl = 'https://www.linkedin.com/psettings/member-data';
             window.loadURL(settingsUrl);
 
@@ -78,7 +92,7 @@ class LinkedIn extends DataRequestProvider {
     dispatchDataRequest = async (): Promise<void> => {
         await this.verifyLoggedInStatus();
 
-        return withSecureWindow<void>(windowParams, async (window) => {
+        return withSecureWindow<void>(this.windowParams, async (window) => {
             window.hide();
 
             await new Promise((resolve) => {
@@ -118,7 +132,7 @@ class LinkedIn extends DataRequestProvider {
     async isDataRequestComplete(): Promise<boolean> {
         await this.verifyLoggedInStatus();
 
-        return withSecureWindow<boolean>(windowParams, async (window) => {
+        return withSecureWindow<boolean>(this.windowParams, async (window) => {
             // Load page URL
             await new Promise((resolve) => {
                 window.webContents.once('did-finish-load', resolve)
@@ -138,7 +152,7 @@ class LinkedIn extends DataRequestProvider {
     }
 
     async parseDataRequest(extractionPath: string): Promise<ProviderFile[]> {
-        return withSecureWindow<ProviderFile[]>(windowParams, async (window) => {
+        return withSecureWindow<ProviderFile[]>(this.windowParams, async (window) => {
             // Load page URL
             await new Promise((resolve) => {
                 window.webContents.once('did-finish-load', resolve)

--- a/src/main/providers/parsers.ts
+++ b/src/main/providers/parsers.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import Facebook from './facebook/parser';
 import Instagram from './instagram/parser';
 import LinkedIn from './linkedin/parser';
@@ -29,5 +31,51 @@ export const parsersByFile: Map<string, ProviderParser> = new Map(
         });
     })
 );
+
+// First map all the providers, then show only the paths that are part of a
+// particular provider, rather than creating a long list of global filenames
+export const parsersByProvider: Map<string, Map<string, ProviderParser>> = new Map(
+    providerParsers.map(([parsers, key]) => {
+        return [
+            key,
+            new Map(parsers.map((parser) => {
+                return [
+                    parser.source,
+                    parser
+                ];
+            }))
+        ];
+    })
+);
+
+/**
+ * More intelligently retrieve a particular parser using a filename that might
+ * include an account name.
+ */
+export function getParserByFileName(filepath: string): ProviderParser | void {
+    // First, we'll split the filename, where the first directory should match
+    // the key of the provider
+    const [provider, ...rest] = filepath.split(path.sep);
+
+    // Then we'll retrieve the particular set of parsers for this provider
+    const parserMap = parsersByProvider.get(provider);
+
+    // GUARD: If the root directory isn't recognized, we cannot parse this file
+    if (!parserMap) {
+        return;
+    }
+
+    // Attempt to retrieve the parser by omitting the first directory after the
+    // root, which in new versions should show the account name
+    let parser: ProviderParser;
+    parser = parserMap.get(rest.slice(1).join('/'));
+
+    // Alternatively, attempt to retrieve the parser using legacy methods
+    if (!parser) {
+        parser = parserMap.get(rest.join('/'));
+    }
+
+    return parser;
+}
 
 export default providerParsers;

--- a/src/main/providers/parsers.ts
+++ b/src/main/providers/parsers.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import Facebook from './facebook/parser';
 import Instagram from './instagram/parser';
 import LinkedIn from './linkedin/parser';
+import Spotify from './spotify/parser';
 import { ProviderParser } from './types';
 
 // Contains an overview of parsers, sorted by their provider
@@ -10,6 +11,7 @@ const providerParsers: [ ProviderParser[], string ][] = [
     [Instagram, 'instagram'],
     [Facebook, 'facebook'],
     [LinkedIn, 'linkedin'],
+    [Spotify, 'spotify'],
 ];
 
 // Contains an overview of parsers, sorted by the file they parse

--- a/src/main/providers/spotify/index.ts
+++ b/src/main/providers/spotify/index.ts
@@ -1,0 +1,156 @@
+import { withSecureWindow } from 'main/lib/create-secure-window';
+import { DataRequestProvider, ProviderFile } from '../types';
+
+const windowParams = {
+    key: 'spotify',
+    origin: 'spotify.com',
+};
+
+class Spotify extends DataRequestProvider {
+    public static key = 'spotify';
+    public static dataRequestIntervalDays = 5;
+
+    async initialise(): Promise<boolean> {
+        await this.verifyLoggedInStatus();
+
+        return true;
+    }
+
+    verifyLoggedInStatus = async (): Promise<Electron.Cookie[]> => {
+        return withSecureWindow<Electron.Cookie[]>(windowParams, (window) => {
+            const settingsUrl = 'https://www.spotify.com/us/account/privacy/';
+            window.loadURL(settingsUrl);
+
+            return new Promise((resolve) => {
+                const eventHandler = async(): Promise<void> => {
+                    // Check if we ended up at the page in an authenticated form
+                    if (settingsUrl === window.webContents.getURL()) {
+                        // If so, we retrieve the cookies
+                        const cookies = await window.webContents.session.cookies.get({});
+                        
+                        resolve(cookies);
+                    } else if (!window.isVisible()) {
+                        // If not, we'll check if we need to open the window for the
+                        // user to enter their credentials.
+                        window.show();
+                    }
+                };
+
+                window.webContents.on('did-navigate', eventHandler);
+                window.webContents.once('did-finish-load', eventHandler);
+            });
+        });
+    }
+
+    update = async (): Promise<false> => {
+        // NOTE: Updating is not supported by Spotify at this point
+        return false;
+    }
+
+    dispatchDataRequest = async (): Promise<void> => {
+        await this.verifyLoggedInStatus();
+
+        return withSecureWindow<void>(windowParams, async (window) => {
+            window.hide();
+
+            await new Promise((resolve) => {
+                window.webContents.on('did-finish-load', resolve)
+                window.loadURL('https://www.spotify.com/us/account/privacy/');
+            });
+
+            // Now we must defer the page to the user, so that they can confirm
+            // the request. We then listen for a succesfull AJAX call 
+            return new Promise((resolve) => {
+                window.webContents.session.webRequest.onCompleted({
+                    urls: [ 'https://*.spotify.com/*' ]
+                }, (details: Electron.OnCompletedListenerDetails) => {
+                    if (details.url.startsWith('https://www.spotify.com/us/account/privacy/download')
+                        && details.statusCode === 200) {
+                        resolve();
+                    }
+                });
+
+                // Ensure that the data request is in JSON format
+                window.webContents.executeJavaScript(`
+                    document.querySelector('button#privacy-open-request-download-modal-button')
+                        .click();
+                `);
+
+                window.show();
+            });     
+        });
+    }
+
+    async isDataRequestComplete(): Promise<boolean> {
+        await this.verifyLoggedInStatus();
+
+        return withSecureWindow<boolean>(windowParams, async (window) => {
+            // Load page URL
+            await new Promise((resolve) => {
+                window.webContents.once('did-finish-load', resolve)
+                window.loadURL('https://www.spotify.com/us/account/privacy/');
+            });
+
+            // Check if the third div is grayed out
+            return window.webContents.executeJavaScript(`
+                !Array.from(document.querySelector('.privacy-download-step-3').classList)
+                    .includes('privacy-grayed-step')
+            `);
+        });
+    }
+
+    async parseDataRequest(): Promise<ProviderFile[]> {
+        return [];
+        /*
+        return withSecureWindow<ProviderFile[]>(windowParams, async (window) => {
+            // Load page URL
+            await new Promise((resolve) => {
+                window.webContents.once('dom-ready', resolve)
+                window.loadURL('https://www.spotify.com/us/account/privacy/');
+            });
+
+            const filePath = path.join(requestSavePath, 'facebook.zip');
+            await new Promise((resolve) => {
+                // Create a handler for any file saving actions
+                window.webContents.session.once('will-download', (event, item) => {
+                    // Save the item to the data folder temporarily
+                    item.setSavePath(filePath);
+                    item.once('done', resolve);
+                });
+
+                // And then trigger the button click
+                window.webContents.executeJavaScript(`
+                    Array.from(document.querySelectorAll('button'))
+                        .find(el => el.textContent === 'Download' || el.textContent === 'Download Again')
+                        .click();
+                `);
+
+                window.show();
+            });
+
+            // We have the ZIP, all that's left to do is unpack it and pipe it to
+            // the repository
+            const zip = new AdmZip(filePath);
+            await new Promise((resolve) => 
+                zip.extractAllToAsync(extractionPath, true, resolve)
+            );
+
+            // Translate this into a form that is readable for the ParserManager
+            const files = zip.getEntries().map((entry): ProviderFile => {
+                return {
+                    filepath: entry.entryName,
+                    data: null,
+                    // data: entry.getData(),
+                };
+            });
+
+            // And dont forget to remove the zip file after it's been processed
+            await fs.promises.unlink(filePath);
+
+            return files;
+        });
+        */
+    }
+}
+
+export default Spotify;

--- a/src/main/providers/spotify/index.ts
+++ b/src/main/providers/spotify/index.ts
@@ -9,11 +9,12 @@ const windowParams = {
 class Spotify extends DataRequestProvider {
     public static key = 'spotify';
     public static dataRequestIntervalDays = 5;
+    public static requiresEmailAccount = true;
 
-    async initialise(): Promise<boolean> {
+    async initialise(): Promise<string> {
         await this.verifyLoggedInStatus();
 
-        return true;
+        return '';
     }
 
     verifyLoggedInStatus = async (): Promise<Electron.Cookie[]> => {

--- a/src/main/providers/spotify/parser.ts
+++ b/src/main/providers/spotify/parser.ts
@@ -1,0 +1,122 @@
+import path from 'path';
+import { Address, PlayedSong, ProvidedDataTypes, ProviderParser } from '../types';
+
+type SpotifyStreamHistorySong = {
+    endTime: string;
+    artistName: string;
+    trackName: string;
+    msPlayed: number;
+}
+
+type SpotifyUserData = {
+    username: string;
+    email: string;
+    country: string;
+    createdFromFacebook: boolean;
+    facebookUid?: string;
+    birthdate: string;
+    gender: string;
+    postalCode?: string;
+    mobileNumber?: string;
+    mobileOperator?: string;
+    mobileBrand?: string;
+    creationTime: string;
+}
+
+const parsers: ProviderParser[] = [
+    {
+        source: path.join('MyData', 'Follow.json'),
+        schemas: [
+            {
+                key: 'followingArtists',
+                type: ProvidedDataTypes.ACCOUNT_FOLLOWING
+            },
+        ]
+    },
+    {
+        source: path.join('MyData', 'Identity.json'),
+        schemas: [
+            {
+                key: 'firstName',
+                type: ProvidedDataTypes.FIRST_NAME
+            },
+            {
+                key: 'lastName',
+                type: ProvidedDataTypes.LAST_NAME
+            },
+        ]
+    },
+    {
+        source: path.join('MyData', 'Inferences.json'),
+        schemas: [
+            {
+                key: 'inferences',
+                type: ProvidedDataTypes.INFERENCE
+            }
+        ]
+    },
+    {
+        source: path.join('MyData', 'StreamingHistory0.json'),
+        schemas: [
+            {
+                type: ProvidedDataTypes.PLAYED_SONG,
+                transformer: (song: SpotifyStreamHistorySong): Partial<PlayedSong> => {
+                    return {
+                        data: {
+                            artist: song.artistName,
+                            track: song.trackName,
+                            playDuration: song.msPlayed,
+                        },
+                        timestamp: new Date(song.endTime),
+                    };
+                }
+            }
+        ]
+    },
+    {
+        source: path.join('MyData', 'Userdata.json'),
+        schemas: [
+            {
+                key: 'username',
+                type: ProvidedDataTypes.USERNAME,
+            },
+            {
+                key: 'email',
+                type: ProvidedDataTypes.EMAIL,
+            },
+            {
+                key: 'country',
+                type: ProvidedDataTypes.COUNTRY,
+            },
+            {
+                key: 'birthdate',
+                type: ProvidedDataTypes.DATE_OF_BIRTH,
+            },
+            {
+                key: 'gender',
+                type: ProvidedDataTypes.GENDER
+            },
+            {
+                key: 'postcalCode',
+                type: ProvidedDataTypes.ADDRESS,
+                transformer: (data: SpotifyUserData['postalCode']): Partial<Address>[] => {
+                    return [{
+                        data: {
+                            zipCode: data
+                        }
+                    }];
+                },
+            },
+            {
+                key: 'mobileNumber',
+                type: ProvidedDataTypes.TELEPHONE_NUMBER,
+            },
+            {
+                key: 'creationTime',
+                type: ProvidedDataTypes.REGISTRATION_DATE,
+            },
+        ]
+    },
+];
+
+export default parsers;

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -175,6 +175,10 @@ export enum ProvidedDataTypes {
     REGISTRATION_DATE = 'registration_date',
     // A mobile device associated with the platform
     MOBILE_DEVICE = 'mobile_device',
+    // An inference about an individual
+    INFERENCE = 'inference',
+    // A song that has been played by the user
+    PLAYED_SONG = 'played_song',
 }
 
 export interface ProviderDatum<D, T = ProvidedDataTypes> {
@@ -211,7 +215,7 @@ export type TelephoneNumber = ProviderDatum<string, ProvidedDataTypes.TELEPHONE_
 export type Device = ProviderDatum<string, ProvidedDataTypes.DEVICE>;
 export type Username = ProviderDatum<string, ProvidedDataTypes.USERNAME>;
 export type PlaceOfResidence = ProviderDatum<string, ProvidedDataTypes.PLACE_OF_RESIDENCE>;
-export type Address = ProviderDatum<{ street?: string; number?: number; state?: string; }, ProvidedDataTypes.ADDRESS>;
+export type Address = ProviderDatum<{ street?: string; number?: number; state?: string; zipCode?: string }, ProvidedDataTypes.ADDRESS>;
 export type Country = ProviderDatum<string, ProvidedDataTypes.COUNTRY>;
 export type Like = ProviderDatum<string, ProvidedDataTypes.LIKE>;
 export type LoginInstance = ProviderDatum<number, ProvidedDataTypes.LOGIN_INSTANCE>;
@@ -246,6 +250,13 @@ export type Currency = ProviderDatum<string, ProvidedDataTypes.CURRENCY>;
 export type EducationExperience = ProviderDatum<{ institution: string; graduated?: boolean; started_at?: Date; graduated_at?: Date, type?: string}, ProvidedDataTypes.EDUCATION_EXPERIENCE>;
 export type RegistrationDate = ProviderDatum<Date, ProvidedDataTypes.REGISTRATION_DATE>;
 export type MobileDevice = ProviderDatum<{ type: string; os?: string; advertiser_id?: string; device_locale?: string;}, ProvidedDataTypes.MOBILE_DEVICE>;
+export type Inference = ProviderDatum<string, ProvidedDataTypes.INFERENCE>;
+export type PlayedSong = ProviderDatum<{
+    artist: string;
+    track: string;
+    // The duration of play in milliseconds
+    playDuration: number;
+}, ProvidedDataTypes.PLAYED_SONG>;
 
 export interface ProviderParser {
     // The file from which the data has originated
@@ -262,7 +273,7 @@ export interface ProviderParser {
         // An optional transformer that is used to translate complex objects
         // into the required shape
         // eslint-disable-next-line
-        transformer?(object: unknown): Partial<ProviderDatum<unknown, unknown>>[];
+        transformer?(object: unknown): Partial<ProviderDatum<unknown, unknown>>[] | Partial<ProviderDatum<unknown, unknown>>;
         // transformer?: (obj: any) => any | any[];
     }[]
 }

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -1,3 +1,5 @@
+import { EmailClient } from 'main/email-client/types';
+
 export interface ProviderFile {
     filepath: string;
     data: Buffer | string;
@@ -20,10 +22,6 @@ export abstract class Provider {
     /** The key under which all files will be stored. Should be filesystem-safe
      * (no spaces, all-lowercase) */
     public static key: string;
-    /** Whether this provider reqiores an email account in order to make its
-     * requests. In this case, the user will be required to choose an email up front,
-     * which in turn will be supplied to the initialise function.*/
-    public static requiresEmailAccount: boolean;
     /** Update the data that is retrieved by this Provider. Should return an
      * object with all new files, so they can be saved to disk. Alternatively,
      * should return false to indicate that no update was carried out. */
@@ -55,6 +53,15 @@ export abstract class DataRequestProvider extends Provider {
     /** The amount of days that are required between successive data requests */
     public static dataRequestIntervalDays: number;
 }
+
+export abstract class EmailDataRequestProvider extends DataRequestProvider {
+    protected email: EmailClient;
+    setEmailClient(email: EmailClient): void {
+        this.email = email;
+    }
+}
+
+export type ProviderUnion = typeof DataRequestProvider | typeof Provider | typeof EmailDataRequestProvider;
 
 export interface DataRequestStatus {
     dispatched?: string;


### PR DESCRIPTION
This branch adds support for the Spotify provider, along with small usability fixes to Aeon. This overhauls the Aeon engine to work based on a set of accounts, rather than hardcoded providers. Additionally, it supports email integration for any providers, that is specifically implemented with Spotify.